### PR TITLE
Add retry/circuit-breaker utilities and apply to scraper

### DIFF
--- a/project/app/utils/retry.py
+++ b/project/app/utils/retry.py
@@ -1,0 +1,230 @@
+"""
+リトライ・サーキットブレーカーユーティリティ
+
+外部 HTTP 呼び出し（スクレイパー・オッズ取得）に適用する
+指数バックオフ + ジッターによるリトライと、
+連続失敗時に一定時間呼び出しをスキップするサーキットブレーカーを提供する
+
+使い方:
+  from app.utils.retry import retry, CircuitBreaker
+
+  # デコレータ方式
+  @retry(max_attempts=3, base_delay=1.0, exceptions=(requests.Timeout,))
+  def fetch_results(url):
+      return requests.get(url, timeout=10)
+
+  # サーキットブレーカー
+  cb = CircuitBreaker(name="boatrace-site", failure_threshold=5, recovery_timeout=60)
+
+  @cb.call
+  def scrape_page(url):
+      return requests.get(url)
+"""
+import functools
+import random
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Optional, Tuple, Type
+
+from app.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+# ============================================================
+# リトライデコレータ
+# ============================================================
+
+def retry(
+    max_attempts: int = 3,
+    base_delay: float = 1.0,
+    max_delay: float = 60.0,
+    backoff_factor: float = 2.0,
+    jitter: bool = True,
+    exceptions: Tuple[Type[Exception], ...] = (Exception,),
+    on_retry: Optional[Callable] = None,
+):
+    """
+    指数バックオフ + ジッターによるリトライデコレータ
+
+    Args:
+        max_attempts: 最大試行回数（初回含む）
+        base_delay: 初回リトライまでの待機秒数
+        max_delay: 最大待機秒数（バックオフ上限）
+        backoff_factor: バックオフ倍率（デフォルト 2.0 = 1s, 2s, 4s, ...）
+        jitter: True の場合、待機時間にランダムなばらつきを加える
+        exceptions: リトライ対象の例外クラスタプル
+        on_retry: リトライ時に呼び出すコールバック (attempt, exc) -> None
+
+    使い方:
+        @retry(max_attempts=3, base_delay=2.0, exceptions=(requests.Timeout,))
+        def fetch(url: str) -> str:
+            return requests.get(url).text
+    """
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs) -> Any:
+            last_exc: Optional[Exception] = None
+
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    return func(*args, **kwargs)
+                except exceptions as exc:
+                    last_exc = exc
+
+                    if attempt == max_attempts:
+                        logger.error(
+                            f"[retry] {func.__name__} 最大試行回数到達 "
+                            f"({max_attempts}/{max_attempts}): {exc}"
+                        )
+                        raise
+
+                    delay = min(base_delay * (backoff_factor ** (attempt - 1)), max_delay)
+                    if jitter:
+                        delay *= (0.5 + random.random() * 0.5)  # 50%〜100% のランダム
+
+                    logger.warning(
+                        f"[retry] {func.__name__} 失敗 ({attempt}/{max_attempts}), "
+                        f"{delay:.2f}s 後にリトライ: {exc}"
+                    )
+
+                    if on_retry:
+                        on_retry(attempt, exc)
+
+                    time.sleep(delay)
+
+            raise last_exc  # 到達しないが型チェック用
+
+        return wrapper
+    return decorator
+
+
+# ============================================================
+# サーキットブレーカー
+# ============================================================
+
+class CircuitState(Enum):
+    CLOSED   = "closed"    # 正常: リクエスト通過
+    OPEN     = "open"      # 障害: リクエスト拒否
+    HALF_OPEN = "half_open"  # 復旧試行中
+
+
+@dataclass
+class CircuitBreaker:
+    """
+    サーキットブレーカー実装
+
+    状態遷移:
+      CLOSED → (failure_threshold 回連続失敗) → OPEN
+      OPEN   → (recovery_timeout 秒経過)       → HALF_OPEN
+      HALF_OPEN → (成功)                        → CLOSED
+      HALF_OPEN → (失敗)                        → OPEN
+
+    使い方:
+        cb = CircuitBreaker("boatrace-site", failure_threshold=5, recovery_timeout=60)
+
+        @cb.call
+        def scrape(url):
+            return requests.get(url)
+
+        # または明示的に
+        result = cb.execute(lambda: requests.get(url))
+    """
+    name: str
+    failure_threshold: int = 5       # OPEN に遷移する連続失敗回数
+    recovery_timeout: float = 60.0   # OPEN → HALF_OPEN の待機秒数
+    success_threshold: int = 1       # HALF_OPEN → CLOSED に必要な連続成功回数
+
+    _state: CircuitState = field(default=CircuitState.CLOSED, init=False, repr=False)
+    _failure_count: int = field(default=0, init=False, repr=False)
+    _success_count: int = field(default=0, init=False, repr=False)
+    _last_failure_time: float = field(default=0.0, init=False, repr=False)
+
+    @property
+    def state(self) -> CircuitState:
+        if self._state == CircuitState.OPEN:
+            elapsed = time.monotonic() - self._last_failure_time
+            if elapsed >= self.recovery_timeout:
+                logger.info(f"[circuit:{self.name}] OPEN → HALF_OPEN (経過: {elapsed:.0f}s)")
+                self._state = CircuitState.HALF_OPEN
+                self._success_count = 0
+        return self._state
+
+    def _on_success(self) -> None:
+        if self._state == CircuitState.HALF_OPEN:
+            self._success_count += 1
+            if self._success_count >= self.success_threshold:
+                logger.info(f"[circuit:{self.name}] HALF_OPEN → CLOSED")
+                self._state = CircuitState.CLOSED
+                self._failure_count = 0
+        elif self._state == CircuitState.CLOSED:
+            self._failure_count = 0  # 成功でリセット
+
+    def _on_failure(self, exc: Exception) -> None:
+        self._failure_count += 1
+        self._last_failure_time = time.monotonic()
+
+        if self._state == CircuitState.HALF_OPEN:
+            logger.warning(f"[circuit:{self.name}] HALF_OPEN → OPEN (復旧失敗): {exc}")
+            self._state = CircuitState.OPEN
+        elif self._state == CircuitState.CLOSED:
+            if self._failure_count >= self.failure_threshold:
+                logger.error(
+                    f"[circuit:{self.name}] CLOSED → OPEN "
+                    f"(連続失敗 {self._failure_count} 回): {exc}"
+                )
+                self._state = CircuitState.OPEN
+
+    def execute(self, func: Callable, *args, **kwargs) -> Any:
+        """
+        サーキットブレーカー経由で関数を実行する
+
+        Args:
+            func: 実行する関数
+            *args, **kwargs: func に渡す引数
+
+        Raises:
+            CircuitOpenError: サーキットが OPEN 状態の場合
+            Exception: func が送出した例外
+        """
+        if self.state == CircuitState.OPEN:
+            raise CircuitOpenError(
+                f"サーキット '{self.name}' が OPEN です。"
+                f"復旧まで約 {self.recovery_timeout:.0f}s 待機してください。"
+            )
+
+        try:
+            result = func(*args, **kwargs)
+            self._on_success()
+            return result
+        except CircuitOpenError:
+            raise
+        except Exception as exc:
+            self._on_failure(exc)
+            raise
+
+    def call(self, func: Callable) -> Callable:
+        """デコレータとして使用するためのメソッド"""
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs) -> Any:
+            return self.execute(func, *args, **kwargs)
+        return wrapper
+
+    @property
+    def stats(self) -> dict:
+        """現在の状態統計を返す"""
+        return {
+            "name": self.name,
+            "state": self.state.value,
+            "failure_count": self._failure_count,
+            "last_failure_ago_sec": (
+                round(time.monotonic() - self._last_failure_time, 1)
+                if self._last_failure_time else None
+            ),
+        }
+
+
+class CircuitOpenError(Exception):
+    """サーキットブレーカーが OPEN 状態のときに発生する例外"""
+    pass

--- a/project/scraper.py
+++ b/project/scraper.py
@@ -38,6 +38,8 @@ import logging
 import requests
 from bs4 import BeautifulSoup
 
+from app.utils.retry import CircuitBreaker, CircuitOpenError, retry
+
 # ---- 設定 ----
 BASE_URL = "https://www.boatrace.jp"  # 公式サイト（robots.txt要確認）
 RESULTS_URL = f"{BASE_URL}/owpc/pc/race/resultlist"
@@ -46,8 +48,6 @@ MOTOR_URL = f"{BASE_URL}/owpc/pc/data/motorInfo"
 
 MIN_SLEEP = 2.0   # リクエスト間の最小待機秒数（robots.txt の Crawl-delay に従う）
 MAX_SLEEP = 5.0   # リクエスト間の最大待機秒数
-MAX_RETRY = 3     # リトライ最大回数
-RETRY_BACKOFF = 2.0  # リトライ間隔の基底（指数バックオフ）
 
 OUTPUT_DIR = Path("data/scraped")
 
@@ -57,6 +57,14 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 logger = logging.getLogger(__name__)
+
+# ---- サーキットブレーカー（公式サイトへの過剰アクセスを防止） ----
+_site_cb = CircuitBreaker(
+    name="boatrace-site",
+    failure_threshold=5,    # 5回連続失敗で OPEN
+    recovery_timeout=120.0, # 2分後に HALF_OPEN へ
+    success_threshold=2,    # 2回成功で CLOSED に復帰
+)
 
 # HTTPセッション（接続プールの再利用）
 session = requests.Session()
@@ -94,11 +102,29 @@ def check_robots(url: str) -> bool:
     return allowed
 
 
-# ---- HTTPリクエスト（リトライ付き） ----
+# ---- HTTPリクエスト（リトライ + サーキットブレーカー付き） ----
+
+@retry(
+    max_attempts=3,
+    base_delay=2.0,
+    max_delay=30.0,
+    backoff_factor=2.0,
+    jitter=True,
+    exceptions=(requests.exceptions.Timeout, requests.exceptions.ConnectionError),
+)
+def _get_with_retry(url: str, params: Optional[Dict]) -> requests.Response:
+    """
+    タイムアウト・接続エラー時にリトライする内部 GET ヘルパー。
+    404 などの HTTP エラーはリトライしない（呼び出し元で処理する）。
+    """
+    resp = session.get(url, params=params, timeout=15)
+    resp.raise_for_status()
+    return resp
+
 
 def fetch_page(url: str, params: Optional[Dict] = None, dry_run: bool = False) -> Optional[str]:
     """
-    ページHTMLを取得する（指数バックオフリトライ付き）
+    ページHTMLを取得する（リトライ + サーキットブレーカー付き）
 
     Args:
         url: 取得先URL
@@ -115,30 +141,26 @@ def fetch_page(url: str, params: Optional[Dict] = None, dry_run: bool = False) -
     if not check_robots(url):
         return None
 
-    for attempt in range(1, MAX_RETRY + 1):
-        try:
-            resp = session.get(url, params=params, timeout=15)
-            resp.raise_for_status()
-            resp.encoding = resp.apparent_encoding  # 文字コード自動検出
-            logger.info(f"取得成功: {resp.url} ({resp.status_code})")
-            return resp.text
+    try:
+        resp = _site_cb.execute(_get_with_retry, url, params)
+        resp.encoding = resp.apparent_encoding  # 文字コード自動検出
+        logger.info(f"取得成功: {resp.url} ({resp.status_code})")
+        return resp.text
 
-        except requests.exceptions.HTTPError as e:
-            if e.response is not None and e.response.status_code == 404:
-                logger.warning(f"404 Not Found: {url}")
-                return None
-            logger.warning(f"HTTPエラー (試行 {attempt}/{MAX_RETRY}): {e}")
+    except CircuitOpenError as e:
+        logger.error(f"サーキットブレーカー OPEN: {e}")
+        return None
 
-        except requests.exceptions.RequestException as e:
-            logger.warning(f"リクエストエラー (試行 {attempt}/{MAX_RETRY}): {e}")
+    except requests.exceptions.HTTPError as e:
+        if e.response is not None and e.response.status_code == 404:
+            logger.warning(f"404 Not Found: {url}")
+        else:
+            logger.error(f"HTTPエラー（リトライ上限到達）: {e}")
+        return None
 
-        if attempt < MAX_RETRY:
-            wait = RETRY_BACKOFF ** attempt
-            logger.info(f"{wait:.1f}秒後にリトライします...")
-            time.sleep(wait)
-
-    logger.error(f"最大リトライ回数に達しました: {url}")
-    return None
+    except requests.exceptions.RequestException as e:
+        logger.error(f"リクエストエラー（リトライ上限到達）: {e}")
+        return None
 
 
 def polite_sleep() -> None:

--- a/project/tests/test_retry.py
+++ b/project/tests/test_retry.py
@@ -1,0 +1,381 @@
+"""
+リトライ・サーキットブレーカーユーティリティのテスト
+"""
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from app.utils.retry import CircuitBreaker, CircuitOpenError, CircuitState, retry
+
+
+# ============================================================
+# @retry デコレータのテスト
+# ============================================================
+
+class TestRetryDecorator:
+    def test_success_on_first_attempt(self):
+        """初回成功時はそのまま値を返すこと"""
+        call_count = 0
+
+        @retry(max_attempts=3, base_delay=0.0)
+        def ok():
+            nonlocal call_count
+            call_count += 1
+            return "ok"
+
+        assert ok() == "ok"
+        assert call_count == 1
+
+    def test_retries_on_failure_then_succeeds(self):
+        """失敗後にリトライして成功すること"""
+        attempts = []
+
+        @retry(max_attempts=3, base_delay=0.0, jitter=False)
+        def flaky():
+            attempts.append(1)
+            if len(attempts) < 3:
+                raise ValueError("一時的エラー")
+            return "done"
+
+        with patch("time.sleep"):
+            result = flaky()
+
+        assert result == "done"
+        assert len(attempts) == 3
+
+    def test_raises_after_max_attempts(self):
+        """最大試行回数を超えたら例外を送出すること"""
+        call_count = 0
+
+        @retry(max_attempts=3, base_delay=0.0, jitter=False)
+        def always_fails():
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("永続エラー")
+
+        with patch("time.sleep"):
+            with pytest.raises(RuntimeError, match="永続エラー"):
+                always_fails()
+
+        assert call_count == 3
+
+    def test_only_retries_specified_exceptions(self):
+        """指定外の例外はリトライしないこと"""
+        call_count = 0
+
+        @retry(max_attempts=5, base_delay=0.0, exceptions=(ValueError,))
+        def raises_type_error():
+            nonlocal call_count
+            call_count += 1
+            raise TypeError("対象外エラー")
+
+        with pytest.raises(TypeError):
+            raises_type_error()
+
+        assert call_count == 1  # リトライなし
+
+    def test_retries_only_matching_exceptions(self):
+        """指定した例外のみリトライすること"""
+        attempts = []
+
+        @retry(max_attempts=3, base_delay=0.0, jitter=False, exceptions=(ConnectionError,))
+        def flaky():
+            attempts.append(1)
+            if len(attempts) < 2:
+                raise ConnectionError("接続エラー")
+            return "ok"
+
+        with patch("time.sleep"):
+            assert flaky() == "ok"
+        assert len(attempts) == 2
+
+    def test_backoff_delay_increases(self):
+        """バックオフ遅延が指数的に増加すること"""
+        sleep_calls = []
+
+        @retry(max_attempts=4, base_delay=1.0, backoff_factor=2.0, jitter=False)
+        def always_fails():
+            raise ValueError("fail")
+
+        with patch("time.sleep", side_effect=lambda t: sleep_calls.append(t)):
+            with pytest.raises(ValueError):
+                always_fails()
+
+        # 3回スリープ: 1s, 2s, 4s
+        assert len(sleep_calls) == 3
+        assert sleep_calls[0] == pytest.approx(1.0)
+        assert sleep_calls[1] == pytest.approx(2.0)
+        assert sleep_calls[2] == pytest.approx(4.0)
+
+    def test_max_delay_cap(self):
+        """max_delay を超えないこと"""
+        sleep_calls = []
+
+        @retry(max_attempts=5, base_delay=10.0, backoff_factor=10.0, max_delay=15.0, jitter=False)
+        def always_fails():
+            raise ValueError("fail")
+
+        with patch("time.sleep", side_effect=lambda t: sleep_calls.append(t)):
+            with pytest.raises(ValueError):
+                always_fails()
+
+        assert all(s <= 15.0 for s in sleep_calls)
+
+    def test_jitter_reduces_delay(self):
+        """ジッターが有効な場合、遅延が base_delay * factor 未満になること"""
+        sleep_calls = []
+
+        @retry(max_attempts=3, base_delay=10.0, backoff_factor=1.0, jitter=True)
+        def always_fails():
+            raise ValueError("fail")
+
+        with patch("time.sleep", side_effect=lambda t: sleep_calls.append(t)):
+            with pytest.raises(ValueError):
+                always_fails()
+
+        # jitter は 50%〜100% → 最大 10.0、最小 5.0
+        for s in sleep_calls:
+            assert 5.0 <= s <= 10.0 + 1e-9
+
+    def test_on_retry_callback_called(self):
+        """on_retry コールバックがリトライごとに呼ばれること"""
+        retry_calls = []
+
+        @retry(
+            max_attempts=3,
+            base_delay=0.0,
+            jitter=False,
+            on_retry=lambda attempt, exc: retry_calls.append((attempt, str(exc))),
+        )
+        def always_fails():
+            raise ValueError("cb_test")
+
+        with patch("time.sleep"):
+            with pytest.raises(ValueError):
+                always_fails()
+
+        assert len(retry_calls) == 2  # 試行1,2 の失敗後
+        assert retry_calls[0][0] == 1
+        assert retry_calls[1][0] == 2
+        assert "cb_test" in retry_calls[0][1]
+
+    def test_preserves_function_name(self):
+        """デコレータがラップした関数の名前を保持すること"""
+        @retry(max_attempts=1)
+        def my_named_func():
+            return 42
+
+        assert my_named_func.__name__ == "my_named_func"
+
+    def test_returns_value_correctly(self):
+        """関数の戻り値を正しく返すこと"""
+        @retry(max_attempts=1)
+        def compute():
+            return {"result": [1, 2, 3]}
+
+        assert compute() == {"result": [1, 2, 3]}
+
+
+# ============================================================
+# CircuitBreaker のテスト
+# ============================================================
+
+class TestCircuitBreakerInitialState:
+    def test_initial_state_is_closed(self):
+        """初期状態は CLOSED であること"""
+        cb = CircuitBreaker(name="test", failure_threshold=3)
+        assert cb.state == CircuitState.CLOSED
+
+    def test_execute_success_returns_value(self):
+        """成功時に戻り値が返ること"""
+        cb = CircuitBreaker(name="test")
+        result = cb.execute(lambda: 42)
+        assert result == 42
+
+
+class TestCircuitBreakerTransitions:
+    def test_closed_to_open_after_threshold(self):
+        """failure_threshold 回連続失敗で OPEN に遷移すること"""
+        cb = CircuitBreaker(name="test", failure_threshold=3, recovery_timeout=60.0)
+
+        for _ in range(3):
+            with pytest.raises(ValueError):
+                cb.execute(lambda: (_ for _ in ()).throw(ValueError("err")))
+
+        assert cb.state == CircuitState.OPEN
+
+    def test_open_rejects_calls(self):
+        """OPEN 状態でリクエストを拒否すること"""
+        cb = CircuitBreaker(name="test", failure_threshold=2, recovery_timeout=60.0)
+
+        for _ in range(2):
+            with pytest.raises(Exception):
+                cb.execute(lambda: (_ for _ in ()).throw(RuntimeError("fail")))
+
+        assert cb.state == CircuitState.OPEN
+        with pytest.raises(CircuitOpenError):
+            cb.execute(lambda: "should not run")
+
+    def test_open_to_half_open_after_timeout(self):
+        """recovery_timeout 後に HALF_OPEN に遷移すること"""
+        cb = CircuitBreaker(name="test", failure_threshold=1, recovery_timeout=0.05)
+
+        with pytest.raises(RuntimeError):
+            cb.execute(lambda: (_ for _ in ()).throw(RuntimeError("x")))
+
+        assert cb.state == CircuitState.OPEN
+        time.sleep(0.1)
+        assert cb.state == CircuitState.HALF_OPEN
+
+    def test_half_open_success_closes_circuit(self):
+        """HALF_OPEN で成功すると CLOSED に戻ること"""
+        cb = CircuitBreaker(
+            name="test", failure_threshold=1, recovery_timeout=0.05, success_threshold=1
+        )
+
+        with pytest.raises(RuntimeError):
+            cb.execute(lambda: (_ for _ in ()).throw(RuntimeError("x")))
+
+        time.sleep(0.1)
+        assert cb.state == CircuitState.HALF_OPEN
+
+        result = cb.execute(lambda: "recovered")
+        assert result == "recovered"
+        assert cb.state == CircuitState.CLOSED
+
+    def test_half_open_failure_reopens_circuit(self):
+        """HALF_OPEN で失敗すると再び OPEN に戻ること"""
+        cb = CircuitBreaker(name="test", failure_threshold=1, recovery_timeout=0.05)
+
+        with pytest.raises(RuntimeError):
+            cb.execute(lambda: (_ for _ in ()).throw(RuntimeError("x")))
+
+        time.sleep(0.1)
+        assert cb.state == CircuitState.HALF_OPEN
+
+        with pytest.raises(ValueError):
+            cb.execute(lambda: (_ for _ in ()).throw(ValueError("y")))
+
+        assert cb.state == CircuitState.OPEN
+
+    def test_success_resets_failure_count(self):
+        """成功後に失敗カウントがリセットされること"""
+        cb = CircuitBreaker(name="test", failure_threshold=3)
+
+        # 2回失敗（閾値未達）
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                cb.execute(lambda: (_ for _ in ()).throw(RuntimeError("x")))
+
+        assert cb._failure_count == 2
+
+        # 1回成功 → カウントリセット
+        cb.execute(lambda: "ok")
+        assert cb._failure_count == 0
+        assert cb.state == CircuitState.CLOSED
+
+
+class TestCircuitBreakerDecorator:
+    def test_call_decorator_works(self):
+        """@cb.call デコレータとして使えること"""
+        cb = CircuitBreaker(name="deco-test", failure_threshold=5)
+        call_count = 0
+
+        @cb.call
+        def my_func():
+            nonlocal call_count
+            call_count += 1
+            return "hello"
+
+        assert my_func() == "hello"
+        assert call_count == 1
+
+    def test_call_decorator_preserves_name(self):
+        """@cb.call がラップした関数名を保持すること"""
+        cb = CircuitBreaker(name="test")
+
+        @cb.call
+        def named_func():
+            return 1
+
+        assert named_func.__name__ == "named_func"
+
+    def test_call_decorator_propagates_exception(self):
+        """@cb.call が例外を伝播させること"""
+        cb = CircuitBreaker(name="test", failure_threshold=10)
+
+        @cb.call
+        def bad_func():
+            raise ValueError("expected")
+
+        with pytest.raises(ValueError, match="expected"):
+            bad_func()
+
+
+class TestCircuitBreakerStats:
+    def test_stats_returns_dict(self):
+        """stats が辞書を返すこと"""
+        cb = CircuitBreaker(name="stats-test")
+        s = cb.stats
+        assert isinstance(s, dict)
+        assert s["name"] == "stats-test"
+        assert s["state"] == "closed"
+
+    def test_stats_failure_count(self):
+        """stats に失敗カウントが反映されること"""
+        cb = CircuitBreaker(name="stats-test", failure_threshold=5)
+
+        with pytest.raises(RuntimeError):
+            cb.execute(lambda: (_ for _ in ()).throw(RuntimeError("x")))
+
+        assert cb.stats["failure_count"] == 1
+
+    def test_stats_last_failure_ago(self):
+        """stats の last_failure_ago_sec が None でないこと（失敗後）"""
+        cb = CircuitBreaker(name="test")
+
+        with pytest.raises(RuntimeError):
+            cb.execute(lambda: (_ for _ in ()).throw(RuntimeError("x")))
+
+        assert cb.stats["last_failure_ago_sec"] is not None
+        assert cb.stats["last_failure_ago_sec"] >= 0.0
+
+    def test_stats_no_failure_returns_none_for_time(self):
+        """失敗がない場合 last_failure_ago_sec が None であること"""
+        cb = CircuitBreaker(name="fresh")
+        assert cb.stats["last_failure_ago_sec"] is None
+
+
+class TestCircuitOpenError:
+    def test_circuit_open_error_is_exception(self):
+        """`CircuitOpenError` が Exception のサブクラスであること"""
+        assert issubclass(CircuitOpenError, Exception)
+
+    def test_circuit_open_error_message(self):
+        """エラーメッセージを持てること"""
+        err = CircuitOpenError("テストエラー")
+        assert "テストエラー" in str(err)
+
+    def test_circuit_open_error_not_retried_by_circuit(self):
+        """CircuitOpenError がサーキットブレーカーの失敗カウントに含まれないこと"""
+        cb = CircuitBreaker(name="test", failure_threshold=2, recovery_timeout=0.05)
+
+        # まず OPEN にする
+        with pytest.raises(RuntimeError):
+            cb.execute(lambda: (_ for _ in ()).throw(RuntimeError("x")))
+        with pytest.raises(RuntimeError):
+            cb.execute(lambda: (_ for _ in ()).throw(RuntimeError("x")))
+
+        assert cb.state == CircuitState.OPEN
+        failure_count_before = cb._failure_count
+
+        # OPEN の状態で呼ぶと CircuitOpenError → 失敗カウントに加算されない
+        with pytest.raises(CircuitOpenError):
+            cb.execute(lambda: "noop")
+
+        assert cb._failure_count == failure_count_before


### PR DESCRIPTION
- app/utils/retry.py: @retry decorator with exponential backoff + jitter, CircuitBreaker dataclass (CLOSED/OPEN/HALF_OPEN state machine), CircuitOpenError exception
- tests/test_retry.py: 29 tests covering all retry behaviour and all circuit-breaker state transitions
- scraper.py: replace manual retry loop with @retry on _get_with_retry(), wrap fetch_page() in _site_cb CircuitBreaker (failure_threshold=5, recovery_timeout=120 s) – prevents hammering the site during outages

Total test count: 197 passing

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy