### PR TITLE
Add test coverage for logger, db, and management CLI

### DIFF
--- a/project/tests/test_cli.py
+++ b/project/tests/test_cli.py
@@ -1,0 +1,322 @@
+"""
+app/cli.py のテスト
+
+Click の CliRunner を使って各サブコマンドを検証する。
+subprocess 呼び出し系はモックして実行を回避する。
+"""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tests.test_versioning import _PicklableModel
+
+
+# ============================================================
+# フィクスチャ
+# ============================================================
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def cli_registry(tmp_path, monkeypatch):
+    """テスト用 ModelRegistry（バージョン2件登録済み）を返す"""
+    import app.model.versioning as ver_mod
+    monkeypatch.setattr(ver_mod, "MODEL_DIR", tmp_path)
+    monkeypatch.setattr(ver_mod, "REGISTRY_FILE", tmp_path / "registry.json")
+
+    from app.model.versioning import ModelRegistry
+    registry = ModelRegistry()
+    metrics = {
+        "cv_logloss_mean": 1.5, "cv_logloss_std": 0.05,
+        "cv_accuracy_mean": 0.28, "cv_accuracy_std": 0.02,
+        "n_samples": 1000, "feature_columns": ["x"] * 12,
+    }
+    registry.register(_PicklableModel(), metrics)
+    registry.register(_PicklableModel(), metrics)
+    return registry, tmp_path
+
+
+# ============================================================
+# model グループ
+# ============================================================
+
+class TestModelList:
+    def test_exits_zero(self, runner, cli_registry):
+        """model list がエラーなく完了すること"""
+        from app.cli import cli
+        result = runner.invoke(cli, ["model", "list"])
+        assert result.exit_code == 0
+
+
+class TestModelPromote:
+    def test_latest_promotes(self, runner, cli_registry):
+        """--latest --yes で最新を本番に昇格すること"""
+        registry, _ = cli_registry
+        from app.cli import cli
+        result = runner.invoke(cli, ["model", "promote", "--latest", "--yes"])
+        assert result.exit_code == 0
+        # 再読み込みして本番バージョンが設定されていること
+        from app.model.versioning import ModelRegistry
+        reg2 = ModelRegistry()
+        assert reg2.get_production_version() is not None
+
+    def test_specific_version_promotes(self, runner, cli_registry):
+        """--version <name> --yes で特定バージョンを昇格できること"""
+        registry, _ = cli_registry
+        target = registry.list_versions()[0]["version"]
+        from app.cli import cli
+        result = runner.invoke(cli, ["model", "promote", "--version", target, "--yes"])
+        assert result.exit_code == 0
+
+    def test_no_arg_exits_nonzero(self, runner, cli_registry):
+        """引数なしで --version/--latest が無いとエラー終了すること"""
+        from app.cli import cli
+        result = runner.invoke(cli, ["model", "promote"])
+        assert result.exit_code != 0
+
+    def test_latest_without_versions_exits(self, runner, tmp_path, monkeypatch):
+        """--latest でバージョンなしのときエラー終了すること"""
+        import app.model.versioning as ver_mod
+        monkeypatch.setattr(ver_mod, "MODEL_DIR", tmp_path)
+        monkeypatch.setattr(ver_mod, "REGISTRY_FILE", tmp_path / "empty.json")
+
+        from app.cli import cli
+        result = runner.invoke(cli, ["model", "promote", "--latest"])
+        assert result.exit_code != 0
+
+
+class TestModelCleanup:
+    def test_cleanup_no_targets(self, runner, tmp_path, monkeypatch):
+        """削除対象がないとき正常終了すること"""
+        import app.model.versioning as ver_mod
+        monkeypatch.setattr(ver_mod, "MODEL_DIR", tmp_path)
+        monkeypatch.setattr(ver_mod, "REGISTRY_FILE", tmp_path / "empty.json")
+
+        from app.cli import cli
+        result = runner.invoke(cli, ["model", "cleanup", "--keep", "10", "--yes"])
+        assert result.exit_code == 0
+        assert "削除対象なし" in result.output or "登録数" in result.output
+
+    def test_cleanup_removes_extras(self, runner, tmp_path, monkeypatch):
+        """--keep 未満まで削除すること"""
+        import app.model.versioning as ver_mod
+        monkeypatch.setattr(ver_mod, "MODEL_DIR", tmp_path)
+        monkeypatch.setattr(ver_mod, "REGISTRY_FILE", tmp_path / "reg.json")
+
+        from app.model.versioning import ModelRegistry
+        registry = ModelRegistry()
+        metrics = {
+            "cv_logloss_mean": 1.5, "cv_logloss_std": 0.0,
+            "cv_accuracy_mean": 0.2, "cv_accuracy_std": 0.0,
+            "n_samples": 10, "feature_columns": ["x"] * 12,
+        }
+        for _ in range(5):
+            registry.register(_PicklableModel(), metrics)
+
+        from app.cli import cli
+        result = runner.invoke(cli, ["model", "cleanup", "--keep", "2", "--yes"])
+        assert result.exit_code == 0
+
+        reg2 = ModelRegistry()
+        assert len(reg2.list_versions()) <= 2
+
+
+# ============================================================
+# api グループ
+# ============================================================
+
+class TestApiKeygen:
+    def test_generates_one_key(self, runner):
+        """api keygen でキーが1件出力されること"""
+        from app.cli import cli
+        result = runner.invoke(cli, ["api", "keygen"])
+        assert result.exit_code == 0
+        # デフォルトプレフィックス "br" で始まるキーが含まれる
+        assert "br" in result.output
+
+    def test_count_option(self, runner):
+        """--count 3 で3件生成されること"""
+        from app.cli import cli
+        result = runner.invoke(cli, ["api", "keygen", "--count", "3"])
+        assert result.exit_code == 0
+        # 3行以上出力される（ヘッダー含む）
+        assert result.output.count("br") >= 3
+
+    def test_custom_prefix(self, runner):
+        """--prefix を指定したときそのプレフィックスで生成されること"""
+        from app.cli import cli
+        result = runner.invoke(cli, ["api", "keygen", "--prefix", "test"])
+        assert result.exit_code == 0
+        assert "test" in result.output
+
+
+class TestApiHealth:
+    def test_connection_failure_exits_nonzero(self, runner):
+        """到達不能な URL ではエラー終了すること"""
+        import requests
+        with patch("requests.get", side_effect=requests.exceptions.ConnectionError("down")):
+            from app.cli import cli
+            result = runner.invoke(cli, ["api", "health", "--url", "http://localhost:9"])
+        assert result.exit_code != 0
+
+    def test_success_shows_status(self, runner):
+        """正常レスポンス時にステータスが表示されること"""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "status": "ok",
+            "uptime_sec": 123,
+            "checks": {"db": {"status": "ok"}},
+        }
+        with patch("requests.get", return_value=mock_resp):
+            from app.cli import cli
+            result = runner.invoke(cli, ["api", "health"])
+        assert result.exit_code == 0
+        assert "ok" in result.output
+
+
+# ============================================================
+# data グループ
+# ============================================================
+
+class TestDataValidate:
+    def test_missing_file_exits_nonzero(self, runner, tmp_path):
+        """存在しないファイル指定でエラー終了すること"""
+        from app.cli import cli
+        result = runner.invoke(cli, ["data", "validate", "--path", str(tmp_path / "nope.csv")])
+        assert result.exit_code != 0
+        assert "見つかりません" in result.output
+
+
+# ============================================================
+# result グループ
+# ============================================================
+
+class TestResultRecord:
+    def test_creates_json_file(self, runner, tmp_path, monkeypatch):
+        """レース結果 JSON が生成されること"""
+        monkeypatch.chdir(tmp_path)
+        from app.cli import cli
+        result = runner.invoke(cli, ["result", "record", "race_001", "3"])
+        assert result.exit_code == 0
+        path = tmp_path / "data/race_results/race_001.json"
+        assert path.exists()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["race_id"] == "race_001"
+        assert data["true_winner"] == 3
+
+    def test_duplicate_exits_nonzero(self, runner, tmp_path, monkeypatch):
+        """同じ race_id で2回記録するとエラーになること"""
+        monkeypatch.chdir(tmp_path)
+        from app.cli import cli
+        runner.invoke(cli, ["result", "record", "race_dup", "1"])
+        result = runner.invoke(cli, ["result", "record", "race_dup", "2"])
+        assert result.exit_code != 0
+
+    def test_invalid_winner_rejected(self, runner, tmp_path, monkeypatch):
+        """7号艇（範囲外）は Click バリデーションで拒否されること"""
+        monkeypatch.chdir(tmp_path)
+        from app.cli import cli
+        result = runner.invoke(cli, ["result", "record", "race_x", "7"])
+        assert result.exit_code != 0
+
+    def test_with_second_third(self, runner, tmp_path, monkeypatch):
+        """--second / --third オプションが保存されること"""
+        monkeypatch.chdir(tmp_path)
+        from app.cli import cli
+        result = runner.invoke(
+            cli,
+            ["result", "record", "race_ext", "3", "--second", "1", "--third", "5"],
+        )
+        assert result.exit_code == 0
+        data = json.loads((tmp_path / "data/race_results/race_ext.json").read_text())
+        assert data["second_place"] == 1
+        assert data["third_place"] == 5
+
+
+class TestResultSummary:
+    def test_no_results_shows_message(self, runner, tmp_path, monkeypatch):
+        """レコードなしで「記録なし」を出力すること"""
+        monkeypatch.chdir(tmp_path)
+        from app.cli import cli
+        result = runner.invoke(cli, ["result", "summary"])
+        assert result.exit_code == 0
+        assert "記録なし" in result.output
+
+    def test_with_records_shows_hit_rate(self, runner, tmp_path, monkeypatch):
+        """記録があるとき的中率が表示されること"""
+        monkeypatch.chdir(tmp_path)
+        result_dir = tmp_path / "data/race_results"
+        result_dir.mkdir(parents=True)
+        for i in range(5):
+            rec = {
+                "race_id": f"r{i}",
+                "is_correct": i % 2 == 0,
+                "prediction_rank": (i % 6) + 1,
+            }
+            (result_dir / f"r{i}.json").write_text(json.dumps(rec))
+
+        from app.cli import cli
+        result = runner.invoke(cli, ["result", "summary"])
+        assert result.exit_code == 0
+        assert "的中率" in result.output
+
+
+# ============================================================
+# shadow グループ
+# ============================================================
+
+class TestShadowStats:
+    def test_no_log_shows_message(self, runner, tmp_path, monkeypatch):
+        """ログなしで「見つかりません」を表示すること"""
+        monkeypatch.chdir(tmp_path)
+        from app.cli import cli
+        result = runner.invoke(cli, ["shadow", "stats", "--name", "nonexistent"])
+        assert result.exit_code == 0
+        assert "見つかりません" in result.output
+
+    def test_computes_match_rate(self, runner, tmp_path, monkeypatch):
+        """ログから一致率が計算されること"""
+        monkeypatch.chdir(tmp_path)
+        log_dir = tmp_path / "data/shadow_logs"
+        log_dir.mkdir(parents=True)
+        entries = [
+            {"top1_match": True,  "kl_divergence": 0.01},
+            {"top1_match": False, "kl_divergence": 0.05},
+        ]
+        (log_dir / "shadow.jsonl").write_text(
+            "\n".join(json.dumps(e) for e in entries), encoding="utf-8"
+        )
+
+        from app.cli import cli
+        result = runner.invoke(cli, ["shadow", "stats", "--name", "shadow"])
+        assert result.exit_code == 0
+        assert "1位一致率" in result.output
+        assert "50.0%" in result.output
+
+
+# ============================================================
+# エントリー / バージョン
+# ============================================================
+
+class TestCliEntry:
+    def test_version_flag(self, runner):
+        """--version オプションが動作すること"""
+        from app.cli import cli
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0
+        assert "boat-race-ai" in result.output
+
+    def test_help_flag(self, runner):
+        """--help オプションが動作すること"""
+        from app.cli import cli
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0

--- a/project/tests/test_db.py
+++ b/project/tests/test_db.py
@@ -1,0 +1,229 @@
+"""
+app/db.py のテスト
+
+asyncpg は環境に未インストールのため、sys.modules に fake モジュールを注入し
+非同期接続プール／クエリ発行をモックする。
+"""
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# ============================================================
+# ヘルパー
+# ============================================================
+
+def _install_fake_asyncpg(monkeypatch, pool_mock):
+    """sys.modules に fake asyncpg を差し込み、create_pool が pool_mock を返すようにする"""
+    fake = SimpleNamespace(create_pool=AsyncMock(return_value=pool_mock))
+    monkeypatch.setitem(sys.modules, "asyncpg", fake)
+    return fake
+
+
+def _make_pool_mock():
+    """asyncpg.Pool を模した MagicMock を返す"""
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    conn.fetchrow = AsyncMock()
+
+    # acquire() は async context manager
+    class _Acquire:
+        async def __aenter__(self):
+            return conn
+        async def __aexit__(self, *args):
+            return False
+
+    pool = MagicMock()
+    pool.acquire = lambda: _Acquire()
+    pool.close = AsyncMock()
+    pool._conn = conn  # テストから conn にアクセスしやすいように
+    return pool
+
+
+# ============================================================
+# get_pool / close_pool
+# ============================================================
+
+class TestGetPool:
+    @pytest.fixture(autouse=True)
+    def _reset(self, monkeypatch):
+        import app.db as db_mod
+        monkeypatch.setattr(db_mod, "_pool", None)
+
+    @pytest.mark.anyio
+    async def test_import_error_when_asyncpg_missing(self, monkeypatch):
+        """asyncpg 未インストール時に ImportError を発生させること"""
+        monkeypatch.setitem(sys.modules, "asyncpg", None)
+        import app.db as db_mod
+        with pytest.raises(ImportError):
+            await db_mod.get_pool()
+
+    @pytest.mark.anyio
+    async def test_pool_is_cached(self, monkeypatch):
+        """2回目以降はキャッシュされた pool を返すこと"""
+        pool = _make_pool_mock()
+        _install_fake_asyncpg(monkeypatch, pool)
+
+        import app.db as db_mod
+        p1 = await db_mod.get_pool()
+        p2 = await db_mod.get_pool()
+        assert p1 is p2
+        # create_pool は1回しか呼ばれない
+        assert sys.modules["asyncpg"].create_pool.call_count == 1
+
+    @pytest.mark.anyio
+    async def test_close_pool_sets_none(self, monkeypatch):
+        """close_pool 後に _pool が None に戻ること"""
+        pool = _make_pool_mock()
+        _install_fake_asyncpg(monkeypatch, pool)
+
+        import app.db as db_mod
+        await db_mod.get_pool()
+        await db_mod.close_pool()
+        assert db_mod._pool is None
+        pool.close.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_close_pool_noop_when_no_pool(self, monkeypatch):
+        """pool なしで close_pool を呼んでもエラーにならないこと"""
+        import app.db as db_mod
+        await db_mod.close_pool()  # 例外が出ないこと
+
+
+# ============================================================
+# log_prediction
+# ============================================================
+
+class TestLogPrediction:
+    @pytest.fixture(autouse=True)
+    def _reset(self, monkeypatch):
+        import app.db as db_mod
+        monkeypatch.setattr(db_mod, "_pool", None)
+
+    @pytest.mark.anyio
+    async def test_inserts_row(self, monkeypatch):
+        """INSERT クエリが正しい引数で実行されること"""
+        pool = _make_pool_mock()
+        _install_fake_asyncpg(monkeypatch, pool)
+
+        import app.db as db_mod
+        await db_mod.log_prediction(
+            race_id="race_001",
+            request_body={"a": 1},
+            response_body={"b": 2},
+            latency_ms=42,
+        )
+        pool._conn.execute.assert_awaited_once()
+        # 第1引数（SQL文）に "INSERT" を含むこと
+        args = pool._conn.execute.await_args.args
+        assert "INSERT" in args[0]
+        assert args[1] == "race_001"
+        assert args[4] == 42
+
+    @pytest.mark.anyio
+    async def test_swallows_db_errors(self, monkeypatch):
+        """DB 接続エラーを握りつぶして例外を投げないこと"""
+        # asyncpg を注入せず ImportError を発生させ、log_prediction が吸収するか検証
+        monkeypatch.setitem(sys.modules, "asyncpg", None)
+        import app.db as db_mod
+        # 例外が出なければ OK
+        await db_mod.log_prediction("r1", {}, {}, 0)
+
+    @pytest.mark.anyio
+    async def test_handles_none_race_id(self, monkeypatch):
+        """race_id=None を許容すること"""
+        pool = _make_pool_mock()
+        _install_fake_asyncpg(monkeypatch, pool)
+
+        import app.db as db_mod
+        await db_mod.log_prediction(
+            race_id=None,
+            request_body={},
+            response_body={},
+            latency_ms=5,
+        )
+        args = pool._conn.execute.await_args.args
+        assert args[1] is None
+
+    @pytest.mark.anyio
+    async def test_unicode_json_not_escaped(self, monkeypatch):
+        """JSON シリアライズで日本語がエスケープされず保存されること"""
+        pool = _make_pool_mock()
+        _install_fake_asyncpg(monkeypatch, pool)
+
+        import app.db as db_mod
+        await db_mod.log_prediction(
+            race_id="r1",
+            request_body={"場": "江戸川"},
+            response_body={"msg": "成功"},
+            latency_ms=1,
+        )
+        args = pool._conn.execute.await_args.args
+        # ensure_ascii=False なので日本語がそのまま格納される
+        assert "江戸川" in args[2]
+        assert "成功" in args[3]
+
+
+# ============================================================
+# get_prediction_stats
+# ============================================================
+
+class TestGetPredictionStats:
+    @pytest.fixture(autouse=True)
+    def _reset(self, monkeypatch):
+        import app.db as db_mod
+        monkeypatch.setattr(db_mod, "_pool", None)
+
+    @pytest.mark.anyio
+    async def test_returns_dict_from_row(self, monkeypatch):
+        """fetchrow 結果を dict に変換して返すこと"""
+        pool = _make_pool_mock()
+        pool._conn.fetchrow = AsyncMock(return_value={
+            "total_requests": 100,
+            "avg_latency_ms": 45,
+            "max_latency_ms": 300,
+            "oldest_request": None,
+            "latest_request": None,
+        })
+        _install_fake_asyncpg(monkeypatch, pool)
+
+        import app.db as db_mod
+        stats = await db_mod.get_prediction_stats(days=7)
+        assert stats["total_requests"] == 100
+        assert stats["avg_latency_ms"] == 45
+
+    @pytest.mark.anyio
+    async def test_returns_empty_on_error(self, monkeypatch):
+        """例外時に空 dict を返すこと"""
+        monkeypatch.setitem(sys.modules, "asyncpg", None)
+        import app.db as db_mod
+        stats = await db_mod.get_prediction_stats(days=7)
+        assert stats == {}
+
+    @pytest.mark.anyio
+    async def test_returns_empty_when_row_none(self, monkeypatch):
+        """fetchrow が None を返したときに空 dict を返すこと"""
+        pool = _make_pool_mock()
+        pool._conn.fetchrow = AsyncMock(return_value=None)
+        _install_fake_asyncpg(monkeypatch, pool)
+
+        import app.db as db_mod
+        stats = await db_mod.get_prediction_stats(days=7)
+        assert stats == {}
+
+    @pytest.mark.anyio
+    async def test_days_passed_to_query(self, monkeypatch):
+        """days 引数が fetchrow に渡されること"""
+        pool = _make_pool_mock()
+        pool._conn.fetchrow = AsyncMock(return_value={})
+        _install_fake_asyncpg(monkeypatch, pool)
+
+        import app.db as db_mod
+        await db_mod.get_prediction_stats(days=30)
+        args = pool._conn.fetchrow.await_args.args
+        assert args[-1] == 30

--- a/project/tests/test_logger.py
+++ b/project/tests/test_logger.py
@@ -1,0 +1,73 @@
+"""
+app/utils/logger.py のテスト
+"""
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+class TestGetLogger:
+    def test_returns_logger_instance(self):
+        """Logger インスタンスを返すこと"""
+        from app.utils.logger import get_logger
+        logger = get_logger("test.module.x1")
+        assert isinstance(logger, logging.Logger)
+
+    def test_name_is_set(self):
+        """渡した名前が反映されること"""
+        from app.utils.logger import get_logger
+        logger = get_logger("test.module.x2")
+        assert logger.name == "test.module.x2"
+
+    def test_default_level_is_info(self):
+        """デフォルトレベルが INFO であること"""
+        from app.utils.logger import get_logger
+        logger = get_logger("test.module.x3")
+        assert logger.level == logging.INFO
+
+    def test_explicit_level_debug(self):
+        """DEBUG レベルを指定できること"""
+        from app.utils.logger import get_logger
+        logger = get_logger("test.module.x4", log_level="DEBUG")
+        assert logger.level == logging.DEBUG
+
+    def test_explicit_level_warning(self):
+        """WARNING レベルを指定できること"""
+        from app.utils.logger import get_logger
+        logger = get_logger("test.module.x5", log_level="WARNING")
+        assert logger.level == logging.WARNING
+
+    def test_invalid_level_falls_back_to_info(self):
+        """不正なレベル文字列は INFO にフォールバックすること"""
+        from app.utils.logger import get_logger
+        logger = get_logger("test.module.x6", log_level="INVALID")
+        assert logger.level == logging.INFO
+
+    def test_handlers_attached(self):
+        """StreamHandler と RotatingFileHandler が付与されること"""
+        from app.utils.logger import get_logger
+        from logging.handlers import RotatingFileHandler
+        logger = get_logger("test.module.x7")
+        types = {type(h) for h in logger.handlers}
+        assert logging.StreamHandler in {t for t in types for _ in [0] if issubclass(t, logging.StreamHandler)} or \
+               any(isinstance(h, logging.StreamHandler) for h in logger.handlers)
+        assert any(isinstance(h, RotatingFileHandler) for h in logger.handlers)
+
+    def test_second_call_returns_same_handlers(self):
+        """同名で2回呼ぶとハンドラが重複しないこと"""
+        from app.utils.logger import get_logger
+        logger1 = get_logger("test.module.x8")
+        n1 = len(logger1.handlers)
+        logger2 = get_logger("test.module.x8")
+        assert logger1 is logger2
+        assert len(logger2.handlers) == n1
+
+    def test_logs_directory_created(self):
+        """logs/ ディレクトリが作成されること"""
+        from app.utils.logger import get_logger
+        get_logger("test.module.x9")
+        assert Path("logs").exists()


### PR DESCRIPTION
- tests/test_logger.py (9 tests): get_logger level handling, handler attachment, idempotency, logs directory creation
- tests/test_db.py (12 tests): asyncpg mocked via sys.modules injection; pool caching, close, log_prediction insert/error-swallowing/unicode, get_prediction_stats
- tests/test_cli.py (23 tests): Click CliRunner coverage of model/api/ data/result/shadow subcommands

Total test count: 446 passing (+44)

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy