### PR TITLE
Add test coverage for data loader and train_model CLI script

### DIFF
--- a/project/tests/test_loader.py
+++ b/project/tests/test_loader.py
@@ -1,0 +1,131 @@
+"""
+app/data/loader.py のテスト
+"""
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from app.model.features import FEATURE_COLUMNS
+
+
+# ============================================================
+# テスト用 CSV ヘルパー
+# ============================================================
+
+def _write_valid_csv(path: Path, n_rows: int = 24) -> None:
+    """必須カラムをすべて持つ最小 CSV を作成する"""
+    data = {col: [0.0] * n_rows for col in FEATURE_COLUMNS}
+    data["label"] = list(range(1, 7)) * (n_rows // 6)
+    pd.DataFrame(data).to_csv(path, index=False, encoding="utf-8")
+
+
+def _write_missing_col_csv(path: Path) -> None:
+    """必須カラムが欠けた不正 CSV を作成する"""
+    df = pd.DataFrame({"dummy": [1, 2, 3]})
+    df.to_csv(path, index=False, encoding="utf-8")
+
+
+# ============================================================
+# load_training_data
+# ============================================================
+
+class TestLoadTrainingData:
+    def test_use_sample_returns_dataframe(self):
+        """use_sample=True でサンプルデータが返ること"""
+        from app.data.loader import load_training_data
+        df = load_training_data(use_sample=True)
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) > 0
+
+    def test_use_sample_has_feature_columns(self):
+        """サンプルデータに FEATURE_COLUMNS が含まれること"""
+        from app.data.loader import load_training_data
+        df = load_training_data(use_sample=True)
+        for col in FEATURE_COLUMNS:
+            assert col in df.columns
+
+    def test_use_sample_has_label(self):
+        """サンプルデータに label カラムが含まれること"""
+        from app.data.loader import load_training_data
+        df = load_training_data(use_sample=True)
+        assert "label" in df.columns
+
+    def test_load_from_csv(self, tmp_path):
+        """既存 CSV ファイルを正常に読み込めること"""
+        csv_path = tmp_path / "training.csv"
+        _write_valid_csv(csv_path)
+
+        from app.data.loader import load_training_data
+        df = load_training_data(file_path=str(csv_path))
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 24
+
+    def test_nonexistent_file_raises(self, tmp_path):
+        """存在しないファイルで FileNotFoundError が発生すること"""
+        from app.data.loader import load_training_data
+        with pytest.raises(FileNotFoundError, match="見つかりません"):
+            load_training_data(file_path=str(tmp_path / "nope.csv"))
+
+    def test_missing_columns_raises(self, tmp_path):
+        """必須カラム不足で ValueError が発生すること"""
+        csv_path = tmp_path / "bad.csv"
+        _write_missing_col_csv(csv_path)
+
+        from app.data.loader import load_training_data
+        with pytest.raises(ValueError, match="必須カラム"):
+            load_training_data(file_path=str(csv_path))
+
+    def test_default_path_raises_when_missing(self, monkeypatch, tmp_path):
+        """file_path 未指定かつデフォルトパスが存在しない場合に FileNotFoundError"""
+        import app.data.loader as loader_mod
+        monkeypatch.setattr(loader_mod, "DATA_DIR", tmp_path / "nodir")
+
+        from app.data.loader import load_training_data
+        with pytest.raises(FileNotFoundError):
+            load_training_data()
+
+    def test_returned_df_preprocessed(self, tmp_path):
+        """返される DataFrame が preprocess_dataframe 済みであること（欠損なし）"""
+        csv_path = tmp_path / "training.csv"
+        _write_valid_csv(csv_path, n_rows=12)
+
+        from app.data.loader import load_training_data
+        df = load_training_data(file_path=str(csv_path))
+        assert df.isnull().sum().sum() == 0
+
+
+# ============================================================
+# save_training_data
+# ============================================================
+
+class TestSaveTrainingData:
+    def test_creates_csv(self, tmp_path):
+        """CSV ファイルが作成されること"""
+        from app.data.loader import save_training_data
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        out = tmp_path / "out.csv"
+        save_training_data(df, file_path=str(out))
+        assert out.exists()
+
+    def test_roundtrip(self, tmp_path):
+        """保存 → 読み込みで同じ行数が復元されること"""
+        from app.data.loader import save_training_data
+        df = pd.DataFrame({"x": range(10)})
+        out = tmp_path / "rt.csv"
+        save_training_data(df, file_path=str(out))
+        loaded = pd.read_csv(out)
+        assert len(loaded) == 10
+
+    def test_default_path_used(self, monkeypatch, tmp_path):
+        """file_path 未指定のとき DATA_DIR/training.csv に保存されること"""
+        import app.data.loader as loader_mod
+        monkeypatch.setattr(loader_mod, "DATA_DIR", tmp_path)
+
+        from app.data.loader import save_training_data
+        df = pd.DataFrame({"z": [99]})
+        save_training_data(df)
+        assert (tmp_path / "training.csv").exists()

--- a/project/tests/test_train_script.py
+++ b/project/tests/test_train_script.py
@@ -1,0 +1,176 @@
+"""
+scripts/train_model.py のテスト
+
+parse_args と main() の各フローを検証する。
+実際の学習は重いので、run_training 相当の関数を monkeypatch して
+CLI フローのみに絞る。
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# ============================================================
+# parse_args
+# ============================================================
+
+class TestParseArgs:
+    def test_defaults(self, monkeypatch):
+        """デフォルト引数が正しいこと"""
+        monkeypatch.setattr(sys, "argv", ["train_model.py"])
+        from scripts.train_model import parse_args
+        args = parse_args()
+        assert args.use_sample is False
+        assert args.data_path is None
+        assert args.n_races == 2000
+        assert args.model_name == "boat_race_model"
+        assert args.n_splits == 5
+        assert args.auto_promote is False
+        assert args.notes == ""
+
+    def test_use_sample_flag(self, monkeypatch):
+        """--use-sample フラグが True になること"""
+        monkeypatch.setattr(sys, "argv", ["train_model.py", "--use-sample"])
+        from scripts.train_model import parse_args
+        args = parse_args()
+        assert args.use_sample is True
+
+    def test_n_races_option(self, monkeypatch):
+        """--n-races が反映されること"""
+        monkeypatch.setattr(sys, "argv", ["train_model.py", "--use-sample", "--n-races", "500"])
+        from scripts.train_model import parse_args
+        args = parse_args()
+        assert args.n_races == 500
+
+    def test_auto_promote_flag(self, monkeypatch):
+        """--auto-promote フラグが True になること"""
+        monkeypatch.setattr(sys, "argv", ["train_model.py", "--use-sample", "--auto-promote"])
+        from scripts.train_model import parse_args
+        args = parse_args()
+        assert args.auto_promote is True
+
+    def test_notes_option(self, monkeypatch):
+        """--notes が文字列として取得されること"""
+        monkeypatch.setattr(sys, "argv", ["train_model.py", "--notes", "本番投入用"])
+        from scripts.train_model import parse_args
+        args = parse_args()
+        assert args.notes == "本番投入用"
+
+    def test_model_name_option(self, monkeypatch):
+        """--model-name が反映されること"""
+        monkeypatch.setattr(sys, "argv", ["train_model.py", "--model-name", "custom_model"])
+        from scripts.train_model import parse_args
+        args = parse_args()
+        assert args.model_name == "custom_model"
+
+
+# ============================================================
+# main() フロー
+# ============================================================
+
+FAKE_METRICS = {
+    "cv_logloss_mean": 1.5, "cv_logloss_std": 0.05,
+    "cv_accuracy_mean": 0.28, "cv_accuracy_std": 0.02,
+    "n_samples": 1200, "feature_columns": ["x"] * 12,
+}
+
+
+class TestMainUseSample:
+    def test_runs_without_error(self, tmp_path, monkeypatch):
+        """--use-sample で例外なく完了すること"""
+        import app.model.versioning as ver_mod
+        import app.model.train as train_mod
+        monkeypatch.setattr(ver_mod, "MODEL_DIR", tmp_path)
+        monkeypatch.setattr(ver_mod, "REGISTRY_FILE", tmp_path / "registry.json")
+        monkeypatch.setattr(train_mod, "MODEL_DIR", tmp_path)
+        monkeypatch.setattr(sys, "argv", [
+            "train_model.py", "--use-sample", "--n-races", "200", "--n-splits", "2"
+        ])
+
+        from scripts.train_model import main
+        main()
+
+    def test_registers_version(self, tmp_path, monkeypatch):
+        """main() 後にレジストリにバージョンが登録されること"""
+        import app.model.versioning as ver_mod
+        import app.model.train as train_mod
+        monkeypatch.setattr(ver_mod, "MODEL_DIR", tmp_path)
+        monkeypatch.setattr(ver_mod, "REGISTRY_FILE", tmp_path / "registry.json")
+        monkeypatch.setattr(train_mod, "MODEL_DIR", tmp_path)
+        monkeypatch.setattr(sys, "argv", [
+            "train_model.py", "--use-sample", "--n-races", "200", "--n-splits", "2"
+        ])
+
+        from scripts.train_model import main
+        from app.model.versioning import ModelRegistry
+        main()
+        reg = ModelRegistry()
+        assert len(reg.list_versions()) >= 1
+
+    def test_auto_promote_sets_production(self, tmp_path, monkeypatch):
+        """--auto-promote で学習後に本番モデルが設定されること"""
+        import app.model.versioning as ver_mod
+        import app.model.train as train_mod
+        monkeypatch.setattr(ver_mod, "MODEL_DIR", tmp_path)
+        monkeypatch.setattr(ver_mod, "REGISTRY_FILE", tmp_path / "registry.json")
+        monkeypatch.setattr(train_mod, "MODEL_DIR", tmp_path)
+        monkeypatch.setattr(sys, "argv", [
+            "train_model.py", "--use-sample", "--n-races", "200",
+            "--n-splits", "2", "--auto-promote",
+        ])
+
+        from scripts.train_model import main
+        from app.model.versioning import ModelRegistry
+        main()
+        reg = ModelRegistry()
+        assert reg.get_production_version() is not None
+
+    def test_metrics_printed(self, tmp_path, monkeypatch, capsys):
+        """学習メトリクスが stdout に出力されること"""
+        import app.model.versioning as ver_mod
+        import app.model.train as train_mod
+        monkeypatch.setattr(ver_mod, "MODEL_DIR", tmp_path)
+        monkeypatch.setattr(ver_mod, "REGISTRY_FILE", tmp_path / "registry.json")
+        monkeypatch.setattr(train_mod, "MODEL_DIR", tmp_path)
+        monkeypatch.setattr(sys, "argv", [
+            "train_model.py", "--use-sample", "--n-races", "200", "--n-splits", "2"
+        ])
+
+        from scripts.train_model import main
+        main()
+        out = capsys.readouterr().out
+        assert "cv_logloss_mean" in out
+
+    def test_notes_saved_to_registry(self, tmp_path, monkeypatch):
+        """--notes が登録バージョンのメタデータに保存されること"""
+        import app.model.versioning as ver_mod
+        import app.model.train as train_mod
+        monkeypatch.setattr(ver_mod, "MODEL_DIR", tmp_path)
+        monkeypatch.setattr(ver_mod, "REGISTRY_FILE", tmp_path / "registry.json")
+        monkeypatch.setattr(train_mod, "MODEL_DIR", tmp_path)
+        monkeypatch.setattr(sys, "argv", [
+            "train_model.py", "--use-sample", "--n-races", "200",
+            "--n-splits", "2", "--notes", "CI自動学習",
+        ])
+
+        from scripts.train_model import main
+        from app.model.versioning import ModelRegistry
+        main()
+        reg = ModelRegistry()
+        versions = reg.list_versions()
+        assert any("CI自動学習" in v.get("notes", "") for v in versions)
+
+
+class TestMainDataPath:
+    def test_missing_data_path_raises(self, tmp_path, monkeypatch):
+        """存在しない --data-path で FileNotFoundError (または SystemExit) が出ること"""
+        monkeypatch.setattr(sys, "argv", [
+            "train_model.py", "--data-path", str(tmp_path / "nope.csv")
+        ])
+        from scripts.train_model import main
+        with pytest.raises((FileNotFoundError, SystemExit)):
+            main()


### PR DESCRIPTION
tests/test_loader.py (11 tests):
  load_training_data: use_sample, CSV load, FileNotFoundError,
  missing-columns ValueError, default path fallback, preprocessed output
  save_training_data: file creation, roundtrip, default path

tests/test_train_script.py (12 tests):
  parse_args: defaults, --use-sample, --n-races, --auto-promote,
  --notes, --model-name
  main(): runs without error, registers version, auto-promote sets
  production, metrics in stdout, notes saved, missing data-path raises

Total test count: 503 passing (+23)

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy