### PR TITLE
Add scoring API + fix prediction-result feedback loop

### DIFF
--- a/project/app/api/feedback.py
+++ b/project/app/api/feedback.py
@@ -22,8 +22,9 @@ from app.utils.logger import get_logger
 logger = get_logger(__name__)
 router = APIRouter()
 
-# 結果ログの保存先
-RESULT_LOG_DIR = Path("data/race_results")
+# ログ保存先（テストで monkeypatch 可能なモジュール変数）
+RESULT_LOG_DIR     = Path("data/race_results")
+PREDICTION_LOG_DIR = Path("data/prediction_logs")
 RESULT_LOG_DIR.mkdir(parents=True, exist_ok=True)
 
 
@@ -70,19 +71,36 @@ def _result_path(race_id: str) -> Path:
 
 
 def _load_prediction_log(race_id: str) -> Optional[Dict]:
-    """predict エンドポイントが記録した予測ログを読み込む"""
-    # cache module からキャッシュを確認するか、DB から取得するのが本来の実装
-    # ここでは ab_test ログから検索する（簡易実装）
+    """
+    予測ログを読み込む。
+
+    検索順:
+    1. data/prediction_logs/{race_id}.json  (run_daily_pipeline が保存)
+    2. data/ab_test_logs/*.jsonl            (ab_test ルーターが保存)
+    """
+    # 1. 予測ログディレクトリ（run_daily_pipeline.py の出力）
+    pred_log_path = PREDICTION_LOG_DIR / f"{race_id}.json"
+    if pred_log_path.exists():
+        try:
+            with open(pred_log_path, encoding="utf-8") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # 2. A/B テストログ（フォールバック）
     ab_log_dir = Path("data/ab_test_logs")
     for log_file in ab_log_dir.glob("*.jsonl"):
-        with open(log_file, encoding="utf-8") as f:
-            for line in f:
-                try:
-                    entry = json.loads(line)
-                    if entry.get("race_id") == race_id:
-                        return entry
-                except json.JSONDecodeError:
-                    continue
+        try:
+            with open(log_file, encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        entry = json.loads(line)
+                        if entry.get("race_id") == race_id:
+                            return entry
+                    except json.JSONDecodeError:
+                        continue
+        except OSError:
+            continue
     return None
 
 
@@ -101,7 +119,8 @@ def _compare_prediction(
     if pred_log is None:
         return comparison
 
-    proba = pred_log.get("proba", [])
+    # run_daily_pipeline → "win_probabilities",  ab_test → "proba"
+    proba = pred_log.get("win_probabilities") or pred_log.get("proba", [])
     if not proba:
         return comparison
 

--- a/project/app/api/scoring.py
+++ b/project/app/api/scoring.py
@@ -1,0 +1,260 @@
+"""
+予測スコアリング API
+日次予測ログと実際のレース結果を突き合わせて精度を集計する
+
+エンドポイント:
+  GET /api/v1/scoring/daily          : 日付ごとの的中率
+  GET /api/v1/scoring/by-venue       : 場コードごとの的中率
+  GET /api/v1/scoring/race/{race_id} : 1レース分の予測 vs 結果
+"""
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.api.auth import verify_api_key
+from app.utils.logger import get_logger
+
+logger = get_logger(__name__)
+router = APIRouter()
+
+PREDICTION_LOG_DIR = Path("data/prediction_logs")
+RESULT_LOG_DIR     = Path("data/race_results")
+
+
+# ============================================================
+# スキーマ
+# ============================================================
+
+class RaceScore(BaseModel):
+    race_id:           str
+    jyo_code:          Optional[str] = None
+    race_date:         Optional[str] = None
+    race_no:           Optional[int] = None
+    predicted_winner:  Optional[int] = None
+    true_winner:       Optional[int] = None
+    is_correct:        Optional[bool] = None
+    prediction_rank:   Optional[int] = None
+    has_prediction:    bool = False
+    has_result:        bool = False
+
+
+class DailyScore(BaseModel):
+    date:       str
+    n_races:    int
+    n_scored:   int   # 予測と結果の両方がある件数
+    n_correct:  int
+    hit_rate:   float
+    avg_rank:   float
+
+
+class VenueScore(BaseModel):
+    jyo_code:   str
+    n_races:    int
+    n_scored:   int
+    n_correct:  int
+    hit_rate:   float
+    avg_rank:   float
+
+
+class ScoringOverview(BaseModel):
+    n_predictions:  int
+    n_results:      int
+    n_scored:       int
+    n_correct:      int
+    hit_rate:       float
+    avg_rank:       float
+    by_date:        List[DailyScore]
+    by_venue:       List[VenueScore]
+
+
+# ============================================================
+# ヘルパー
+# ============================================================
+
+def _load_json(path: Path) -> Optional[Dict]:
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _score_pair(pred: Dict, result: Dict) -> RaceScore:
+    """予測ログと結果ログを突き合わせて RaceScore を返す。"""
+    race_id = pred.get("race_id") or result.get("race_id", "unknown")
+
+    proba = pred.get("win_probabilities") or pred.get("proba") or []
+    true_winner = result.get("true_winner")
+
+    predicted_winner: Optional[int] = None
+    is_correct:       Optional[bool] = None
+    pred_rank:        Optional[int]  = None
+
+    if proba and true_winner is not None:
+        import numpy as np
+        arr   = np.array(proba)
+        order = np.argsort(arr)[::-1]          # 確率降順インデックス
+        predicted_winner = int(order[0]) + 1
+        is_correct       = (predicted_winner == true_winner)
+        winner_idx       = true_winner - 1
+        if 0 <= winner_idx < len(arr):
+            pred_rank = int(np.where(order == winner_idx)[0][0]) + 1
+
+    return RaceScore(
+        race_id          = race_id,
+        jyo_code         = pred.get("jyo_code") or result.get("jyo_code"),
+        race_date        = pred.get("race_date") or result.get("race_date"),
+        race_no          = pred.get("race_no")   or result.get("race_no"),
+        predicted_winner = predicted_winner,
+        true_winner      = true_winner,
+        is_correct       = is_correct,
+        prediction_rank  = pred_rank,
+        has_prediction   = True,
+        has_result       = True,
+    )
+
+
+def _collect_scores() -> List[RaceScore]:
+    """全予測ログ × 全結果ログを突き合わせてスコアリストを返す。"""
+    preds   = {p.stem: _load_json(p) for p in PREDICTION_LOG_DIR.glob("*.json")} \
+              if PREDICTION_LOG_DIR.exists() else {}
+    results = {r.stem: _load_json(r) for r in RESULT_LOG_DIR.glob("*.json")} \
+              if RESULT_LOG_DIR.exists() else {}
+
+    scores: List[RaceScore] = []
+    all_ids = set(preds) | set(results)
+
+    for race_id in sorted(all_ids):
+        pred   = preds.get(race_id)
+        result = results.get(race_id)
+
+        if pred and result:
+            scores.append(_score_pair(pred, result))
+        elif pred:
+            scores.append(RaceScore(
+                race_id    = race_id,
+                jyo_code   = pred.get("jyo_code"),
+                race_date  = pred.get("race_date"),
+                race_no    = pred.get("race_no"),
+                has_prediction = True,
+            ))
+        elif result:
+            scores.append(RaceScore(
+                race_id     = race_id,
+                true_winner = result.get("true_winner"),
+                has_result  = True,
+            ))
+
+    return scores
+
+
+def _agg(scores: List[RaceScore]) -> Dict[str, Any]:
+    scored   = [s for s in scores if s.has_prediction and s.has_result and s.is_correct is not None]
+    n_correct = sum(1 for s in scored if s.is_correct)
+    ranks     = [s.prediction_rank for s in scored if s.prediction_rank is not None]
+    return {
+        "n_scored":  len(scored),
+        "n_correct": n_correct,
+        "hit_rate":  round(n_correct / len(scored), 4) if scored else 0.0,
+        "avg_rank":  round(sum(ranks) / len(ranks), 2) if ranks else 0.0,
+    }
+
+
+# ============================================================
+# エンドポイント
+# ============================================================
+
+@router.get(
+    "/scoring",
+    response_model=ScoringOverview,
+    summary="予測スコアリング概要",
+    description="保存済み予測ログとレース結果を突き合わせ、的中率・平均予測順位を集計します。",
+)
+async def scoring_overview(
+    _api_key: str = Depends(verify_api_key),
+) -> ScoringOverview:
+    """全期間の予測精度概要を返す"""
+    scores = _collect_scores()
+    agg    = _agg(scores)
+
+    # 日別集計
+    by_date_map: Dict[str, List[RaceScore]] = defaultdict(list)
+    for s in scores:
+        key = (s.race_date or "unknown")
+        by_date_map[key].append(s)
+
+    by_date = []
+    for dt in sorted(by_date_map):
+        g   = by_date_map[dt]
+        a   = _agg(g)
+        by_date.append(DailyScore(
+            date      = dt,
+            n_races   = len(g),
+            **a,
+        ))
+
+    # 場別集計
+    by_venue_map: Dict[str, List[RaceScore]] = defaultdict(list)
+    for s in scores:
+        key = (s.jyo_code or "unknown")
+        by_venue_map[key].append(s)
+
+    by_venue = []
+    for jyo in sorted(by_venue_map):
+        g = by_venue_map[jyo]
+        a = _agg(g)
+        by_venue.append(VenueScore(
+            jyo_code = jyo,
+            n_races  = len(g),
+            **a,
+        ))
+
+    n_preds   = sum(1 for p in PREDICTION_LOG_DIR.glob("*.json")) \
+                if PREDICTION_LOG_DIR.exists() else 0
+    n_results = sum(1 for r in RESULT_LOG_DIR.glob("*.json")) \
+                if RESULT_LOG_DIR.exists() else 0
+
+    return ScoringOverview(
+        n_predictions = n_preds,
+        n_results     = n_results,
+        by_date       = by_date,
+        by_venue      = by_venue,
+        **agg,
+    )
+
+
+@router.get(
+    "/scoring/race/{race_id}",
+    response_model=RaceScore,
+    summary="1レースのスコア照合",
+)
+async def race_score(
+    race_id: str,
+    _api_key: str = Depends(verify_api_key),
+) -> RaceScore:
+    """指定レースの予測と結果を突き合わせて返す"""
+    pred_path   = PREDICTION_LOG_DIR / f"{race_id}.json"
+    result_path = RESULT_LOG_DIR     / f"{race_id}.json"
+
+    pred   = _load_json(pred_path)   if pred_path.exists()   else None
+    result = _load_json(result_path) if result_path.exists() else None
+
+    if pred is None and result is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"レースID {race_id} の予測も結果も見つかりません",
+        )
+
+    if pred and result:
+        return _score_pair(pred, result)
+
+    return RaceScore(
+        race_id        = race_id,
+        true_winner    = result.get("true_winner") if result else None,
+        has_prediction = pred is not None,
+        has_result     = result is not None,
+    )

--- a/project/app/main.py
+++ b/project/app/main.py
@@ -14,6 +14,7 @@ from app.api.metrics import router as metrics_router, metrics_middleware
 from app.api.feedback import router as feedback_router
 from app.api.admin import router as admin_router
 from app.api.explain import router as explain_router
+from app.api.scoring import router as scoring_router
 from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -116,12 +117,13 @@ app.add_middleware(
 )
 
 # ---- ルーター登録 ----
-app.include_router(predict_router, prefix="/api/v1", tags=["predict"])
-app.include_router(explain_router, prefix="/api/v1", tags=["explain"])
+app.include_router(predict_router,  prefix="/api/v1", tags=["predict"])
+app.include_router(explain_router,  prefix="/api/v1", tags=["explain"])
 app.include_router(feedback_router, prefix="/api/v1", tags=["feedback"])
-app.include_router(admin_router, prefix="/api/v1", tags=["admin"])
-app.include_router(health_router, tags=["health"])
-app.include_router(metrics_router, tags=["observability"])
+app.include_router(scoring_router,  prefix="/api/v1", tags=["scoring"])
+app.include_router(admin_router,    prefix="/api/v1", tags=["admin"])
+app.include_router(health_router,   tags=["health"])
+app.include_router(metrics_router,  tags=["observability"])
 
 
 @app.get("/health", tags=["health"], include_in_schema=False)

--- a/project/tests/test_scoring.py
+++ b/project/tests/test_scoring.py
@@ -1,0 +1,335 @@
+"""
+app/api/scoring.py のテスト
+
+スコアリング集計ロジックと API エンドポイントを検証する。
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from fastapi.testclient import TestClient
+from app.main import app
+from app.api.auth import verify_api_key
+
+app.dependency_overrides[verify_api_key] = lambda: "test-key"
+client = TestClient(app)
+
+
+# ============================================================
+# フィクスチャ
+# ============================================================
+
+def _write_prediction(path: Path, race_id: str, win_proba: list,
+                      jyo_code: str = "01", race_date: str = "20260420",
+                      race_no: int = 1) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    record = {
+        "race_id":          race_id,
+        "jyo_code":         jyo_code,
+        "race_date":        race_date,
+        "race_no":          race_no,
+        "win_probabilities": win_proba,
+        "top1_boat":        win_proba.index(max(win_proba)) + 1,
+        "trifecta_top3":    [[1, 2, 3]],
+        "win_odds":         {},
+        "dry_run":          True,
+        "predicted_at":     "2026-04-20T00:00:00+00:00",
+    }
+    (path / f"{race_id}.json").write_text(
+        json.dumps(record, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+def _write_result(path: Path, race_id: str, true_winner: int,
+                  race_date: str = "20260420") -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    record = {
+        "race_id":     race_id,
+        "true_winner": true_winner,
+        "race_date":   race_date,
+        "recorded_at": "2026-04-20T12:00:00+00:00",
+        "is_correct":  None,
+        "prediction_rank": None,
+    }
+    (path / f"{race_id}.json").write_text(
+        json.dumps(record, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+# ============================================================
+# _score_pair (unit)
+# ============================================================
+
+class TestScorePair:
+    def test_correct_prediction(self):
+        """1号艇が最高確率かつ実際の1着のとき is_correct=True"""
+        from app.api.scoring import _score_pair
+        pred   = {"race_id": "r1", "win_probabilities": [0.5, 0.2, 0.1, 0.1, 0.05, 0.05]}
+        result = {"true_winner": 1}
+        score  = _score_pair(pred, result)
+        assert score.is_correct is True
+        assert score.predicted_winner == 1
+        assert score.prediction_rank == 1
+
+    def test_wrong_prediction(self):
+        """1号艇最高確率だが3号艇が実際の1着のとき is_correct=False"""
+        from app.api.scoring import _score_pair
+        pred   = {"race_id": "r1", "win_probabilities": [0.5, 0.2, 0.15, 0.1, 0.03, 0.02]}
+        result = {"true_winner": 3}
+        score  = _score_pair(pred, result)
+        assert score.is_correct is False
+        assert score.prediction_rank == 3   # 3号艇は確率3位
+
+    def test_accepts_proba_field(self):
+        """旧形式 "proba" フィールドも受け付けること"""
+        from app.api.scoring import _score_pair
+        pred   = {"race_id": "r1", "proba": [0.1, 0.5, 0.1, 0.1, 0.1, 0.1]}
+        result = {"true_winner": 2}
+        score  = _score_pair(pred, result)
+        assert score.is_correct is True
+        assert score.predicted_winner == 2
+
+    def test_no_proba_returns_none_fields(self):
+        """proba なしのとき比較フィールドが None"""
+        from app.api.scoring import _score_pair
+        score = _score_pair({"race_id": "r1"}, {"true_winner": 1})
+        assert score.is_correct is None
+        assert score.predicted_winner is None
+
+
+# ============================================================
+# _collect_scores (unit)
+# ============================================================
+
+class TestCollectScores:
+    def test_matched_pair_scored(self, tmp_path, monkeypatch):
+        """予測と結果が両方あるレースは has_prediction/has_result=True"""
+        import app.api.scoring as sc
+        pred_dir   = tmp_path / "prediction_logs"
+        result_dir = tmp_path / "race_results"
+        monkeypatch.setattr(sc, "PREDICTION_LOG_DIR", pred_dir)
+        monkeypatch.setattr(sc, "RESULT_LOG_DIR",     result_dir)
+
+        _write_prediction(pred_dir, "r1", [0.5, 0.1, 0.1, 0.1, 0.1, 0.1])
+        _write_result(result_dir, "r1", true_winner=1)
+
+        scores = sc._collect_scores()
+        assert len(scores) == 1
+        assert scores[0].has_prediction and scores[0].has_result
+
+    def test_prediction_only(self, tmp_path, monkeypatch):
+        """予測のみ: has_result=False"""
+        import app.api.scoring as sc
+        pred_dir   = tmp_path / "prediction_logs"
+        result_dir = tmp_path / "race_results"
+        monkeypatch.setattr(sc, "PREDICTION_LOG_DIR", pred_dir)
+        monkeypatch.setattr(sc, "RESULT_LOG_DIR",     result_dir)
+        result_dir.mkdir()
+
+        _write_prediction(pred_dir, "r2", [1/6] * 6)
+
+        scores = sc._collect_scores()
+        assert len(scores) == 1
+        assert scores[0].has_prediction is True
+        assert scores[0].has_result is False
+
+    def test_result_only(self, tmp_path, monkeypatch):
+        """結果のみ: has_prediction=False"""
+        import app.api.scoring as sc
+        pred_dir   = tmp_path / "prediction_logs"
+        result_dir = tmp_path / "race_results"
+        monkeypatch.setattr(sc, "PREDICTION_LOG_DIR", pred_dir)
+        monkeypatch.setattr(sc, "RESULT_LOG_DIR",     result_dir)
+        pred_dir.mkdir()
+
+        _write_result(result_dir, "r3", true_winner=4)
+
+        scores = sc._collect_scores()
+        assert scores[0].has_prediction is False
+        assert scores[0].has_result is True
+
+    def test_empty_dirs_returns_empty(self, tmp_path, monkeypatch):
+        """空ディレクトリで空リストを返すこと"""
+        import app.api.scoring as sc
+        pred_dir   = tmp_path / "preds";  pred_dir.mkdir()
+        result_dir = tmp_path / "results"; result_dir.mkdir()
+        monkeypatch.setattr(sc, "PREDICTION_LOG_DIR", pred_dir)
+        monkeypatch.setattr(sc, "RESULT_LOG_DIR",     result_dir)
+        assert sc._collect_scores() == []
+
+
+# ============================================================
+# GET /api/v1/scoring
+# ============================================================
+
+class TestScoringEndpoint:
+    def test_returns_200(self, tmp_path, monkeypatch):
+        """エンドポイントが 200 を返すこと"""
+        import app.api.scoring as sc
+        pred_dir   = tmp_path / "prediction_logs"; pred_dir.mkdir()
+        result_dir = tmp_path / "race_results";    result_dir.mkdir()
+        monkeypatch.setattr(sc, "PREDICTION_LOG_DIR", pred_dir)
+        monkeypatch.setattr(sc, "RESULT_LOG_DIR",     result_dir)
+
+        resp = client.get("/api/v1/scoring")
+        assert resp.status_code == 200
+
+    def test_response_schema(self, tmp_path, monkeypatch):
+        """レスポンスに必須フィールドが含まれること"""
+        import app.api.scoring as sc
+        pred_dir   = tmp_path / "prediction_logs"; pred_dir.mkdir()
+        result_dir = tmp_path / "race_results";    result_dir.mkdir()
+        monkeypatch.setattr(sc, "PREDICTION_LOG_DIR", pred_dir)
+        monkeypatch.setattr(sc, "RESULT_LOG_DIR",     result_dir)
+
+        body = client.get("/api/v1/scoring").json()
+        for key in ("n_predictions", "n_results", "n_scored", "hit_rate", "by_date", "by_venue"):
+            assert key in body
+
+    def test_hit_rate_correct(self, tmp_path, monkeypatch):
+        """2勝1敗のとき hit_rate ≈ 0.667"""
+        import app.api.scoring as sc
+        pred_dir   = tmp_path / "prediction_logs"
+        result_dir = tmp_path / "race_results"
+        monkeypatch.setattr(sc, "PREDICTION_LOG_DIR", pred_dir)
+        monkeypatch.setattr(sc, "RESULT_LOG_DIR",     result_dir)
+
+        # 1号艇最高確率 → 1着が来れば的中
+        _write_prediction(pred_dir, "r1", [0.5, 0.1, 0.1, 0.1, 0.1, 0.1])
+        _write_prediction(pred_dir, "r2", [0.5, 0.1, 0.1, 0.1, 0.1, 0.1])
+        _write_prediction(pred_dir, "r3", [0.5, 0.1, 0.1, 0.1, 0.1, 0.1])
+        _write_result(result_dir, "r1", true_winner=1)   # 的中
+        _write_result(result_dir, "r2", true_winner=1)   # 的中
+        _write_result(result_dir, "r3", true_winner=3)   # 外れ
+
+        body = client.get("/api/v1/scoring").json()
+        assert body["n_scored"] == 3
+        assert body["n_correct"] == 2
+        assert abs(body["hit_rate"] - 2/3) < 0.01
+
+    def test_by_date_grouping(self, tmp_path, monkeypatch):
+        """日別集計が by_date に含まれること"""
+        import app.api.scoring as sc
+        pred_dir   = tmp_path / "prediction_logs"
+        result_dir = tmp_path / "race_results"
+        monkeypatch.setattr(sc, "PREDICTION_LOG_DIR", pred_dir)
+        monkeypatch.setattr(sc, "RESULT_LOG_DIR",     result_dir)
+
+        _write_prediction(pred_dir, "20260420_01_R01", [0.5, 0.1, 0.1, 0.1, 0.1, 0.1],
+                          race_date="20260420")
+        _write_result(result_dir, "20260420_01_R01", true_winner=1)
+
+        body = client.get("/api/v1/scoring").json()
+        assert len(body["by_date"]) >= 1
+        assert any(d["date"] == "20260420" for d in body["by_date"])
+
+    def test_by_venue_grouping(self, tmp_path, monkeypatch):
+        """場別集計が by_venue に含まれること"""
+        import app.api.scoring as sc
+        pred_dir   = tmp_path / "prediction_logs"
+        result_dir = tmp_path / "race_results"
+        monkeypatch.setattr(sc, "PREDICTION_LOG_DIR", pred_dir)
+        monkeypatch.setattr(sc, "RESULT_LOG_DIR",     result_dir)
+
+        _write_prediction(pred_dir, "20260420_06_R01", [0.5, 0.1, 0.1, 0.1, 0.1, 0.1],
+                          jyo_code="06")
+        _write_result(result_dir, "20260420_06_R01", true_winner=1)
+
+        body = client.get("/api/v1/scoring").json()
+        assert any(v["jyo_code"] == "06" for v in body["by_venue"])
+
+
+# ============================================================
+# GET /api/v1/scoring/race/{race_id}
+# ============================================================
+
+class TestRaceScoreEndpoint:
+    def test_both_present_returns_200(self, tmp_path, monkeypatch):
+        """予測と結果が両方あるとき 200 を返すこと"""
+        import app.api.scoring as sc
+        pred_dir   = tmp_path / "prediction_logs"
+        result_dir = tmp_path / "race_results"
+        monkeypatch.setattr(sc, "PREDICTION_LOG_DIR", pred_dir)
+        monkeypatch.setattr(sc, "RESULT_LOG_DIR",     result_dir)
+
+        _write_prediction(pred_dir, "r_single", [0.4, 0.2, 0.1, 0.1, 0.1, 0.1])
+        _write_result(result_dir, "r_single", true_winner=1)
+
+        resp = client.get("/api/v1/scoring/race/r_single")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["is_correct"] is True
+        assert body["predicted_winner"] == 1
+
+    def test_missing_returns_404(self, tmp_path, monkeypatch):
+        """予測も結果もないとき 404 を返すこと"""
+        import app.api.scoring as sc
+        pred_dir   = tmp_path / "prediction_logs"; pred_dir.mkdir()
+        result_dir = tmp_path / "race_results";    result_dir.mkdir()
+        monkeypatch.setattr(sc, "PREDICTION_LOG_DIR", pred_dir)
+        monkeypatch.setattr(sc, "RESULT_LOG_DIR",     result_dir)
+
+        resp = client.get("/api/v1/scoring/race/no_such_race")
+        assert resp.status_code == 404
+
+    def test_prediction_only_returns_200(self, tmp_path, monkeypatch):
+        """予測のみでも 200 を返すこと（has_result=False）"""
+        import app.api.scoring as sc
+        pred_dir   = tmp_path / "prediction_logs"
+        result_dir = tmp_path / "race_results"; result_dir.mkdir()
+        monkeypatch.setattr(sc, "PREDICTION_LOG_DIR", pred_dir)
+        monkeypatch.setattr(sc, "RESULT_LOG_DIR",     result_dir)
+
+        _write_prediction(pred_dir, "r_pred_only", [1/6] * 6)
+
+        resp = client.get("/api/v1/scoring/race/r_pred_only")
+        assert resp.status_code == 200
+        assert resp.json()["has_prediction"] is True
+        assert resp.json()["has_result"] is False
+
+
+# ============================================================
+# feedback.py の _load_prediction_log 修正テスト
+# ============================================================
+
+class TestLoadPredictionLogFix:
+    def test_reads_from_prediction_logs_dir(self, tmp_path, monkeypatch):
+        """data/prediction_logs/{race_id}.json を読み込めること"""
+        import app.api.feedback as fb
+
+        pred_dir = tmp_path / "prediction_logs"
+        pred_dir.mkdir()
+        record = {
+            "race_id":          "r_fix",
+            "win_probabilities": [0.4, 0.2, 0.1, 0.1, 0.1, 0.1],
+        }
+        (pred_dir / "r_fix.json").write_text(
+            json.dumps(record), encoding="utf-8"
+        )
+        # モジュール変数を tmp_path 以下に向ける
+        monkeypatch.setattr(fb, "PREDICTION_LOG_DIR", pred_dir)
+
+        result = fb._load_prediction_log("r_fix")
+        assert result is not None
+        assert "win_probabilities" in result
+
+    def test_compare_uses_win_probabilities(self, tmp_path, monkeypatch):
+        """win_probabilities フィールドで比較が動くこと"""
+        from app.api.feedback import _compare_prediction, RaceResultRequest
+        import app.api.feedback as fb
+
+        pred_log = {
+            "race_id":          "r_cmp",
+            "win_probabilities": [0.5, 0.1, 0.1, 0.1, 0.1, 0.1],
+        }
+        monkeypatch.setattr(fb, "_load_prediction_log", lambda rid: pred_log)
+
+        req = RaceResultRequest(true_winner=1)
+        cmp = _compare_prediction(req, "r_cmp")
+
+        assert cmp["predicted_winner"] == 1
+        assert cmp["is_correct"] is True


### PR DESCRIPTION
app/api/scoring.py (new):
  GET /api/v1/scoring          — overall hit_rate/avg_rank + by-date +
                                 by-venue breakdown
  GET /api/v1/scoring/race/{id} — single-race prediction vs result

app/api/feedback.py (fix):
  _load_prediction_log() now reads data/prediction_logs/{race_id}.json
  (written by run_daily_pipeline.py) before falling back to ab_test logs.
  _compare_prediction() accepts both "win_probabilities" and "proba" keys.
  Added PREDICTION_LOG_DIR module constant for testability.

app/main.py: register scoring_router at /api/v1

tests/test_scoring.py (18 tests):
  _score_pair: correct/wrong/proba-field/no-proba
  _collect_scores: matched/pred-only/result-only/empty
  GET /api/v1/scoring: 200, schema, hit_rate formula, by_date, by_venue
  GET /api/v1/scoring/race/{id}: 200, 404, pred-only
  TestLoadPredictionLogFix: reads from prediction_logs/, win_probabilities key

Total test count: 548 passing (+18)

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy