### PR TITLE
Add scoring CLI commands and Makefile targets for daily/retrain/ci ops

### DIFF
--- a/project/Makefile
+++ b/project/Makefile
@@ -4,7 +4,8 @@
 # ============================================================
 
 .PHONY: help install train serve test lint fmt docker-build docker-up docker-down \
-        simulate backtest clean result-summary shadow-stats
+        simulate backtest clean result-summary shadow-stats \
+        daily auto-retrain scoring ci
 
 PYTHON   := python
 UVICORN  := uvicorn
@@ -31,6 +32,12 @@ help:
 	@echo "  make shadow-stats    シャドウモード統計表示"
 	@echo "  make drift           ドリフト検知実行"
 	@echo "  make versions        登録済みモデルバージョン一覧"
+	@echo "  make daily           日次予測パイプライン（ドライラン）"
+	@echo "  make daily-live      日次予測パイプライン（本番実行）"
+	@echo "  make auto-retrain    ドリフト検知 → 自動再学習"
+	@echo "  make scoring         予測スコアリング概要表示"
+	@echo "  make ci              lint + テスト（CI チェック）"
+	@echo "  make ci-full         lint + カバレッジ付きテスト"
 	@echo "  make docker-build    Docker イメージビルド"
 	@echo "  make docker-up       docker compose 起動"
 	@echo "  make docker-down     docker compose 停止"
@@ -124,6 +131,33 @@ fetch-odds:
 
 convert-data:
 	$(PYTHON) scripts/convert_data.py --dry-run
+
+# ---- 日次パイプライン・自動再学習 ----
+
+daily:
+	$(PYTHON) scripts/run_daily_pipeline.py --dry-run
+
+daily-live:
+	$(PYTHON) scripts/run_daily_pipeline.py
+
+auto-retrain:
+	$(PYTHON) scripts/auto_retrain.py
+
+# ---- スコアリング ----
+
+scoring:
+	$(PYTHON) -m app.cli scoring overview
+
+scoring-race:
+	$(PYTHON) -m app.cli scoring race $(RACE)
+
+# ---- CI（lint + test） ----
+
+ci: lint test
+	@echo "CI チェック完了"
+
+ci-full: lint test-cov
+	@echo "CI フルチェック完了"
 
 # ---- CLI ----
 cli:

--- a/project/app/cli.py
+++ b/project/app/cli.py
@@ -514,6 +514,175 @@ def result_summary(n):
 
 
 # ============================================================
+# scoring グループ（予測スコアリング）
+# ============================================================
+
+@cli.group()
+def scoring():
+    """予測スコアリング管理コマンド"""
+    pass
+
+
+@scoring.command("overview")
+@click.option("--date", default=None, help="集計対象日 (YYYYMMDD)")
+@click.option("--venue", "-v", default=None, help="場コードでフィルター (01〜24)")
+def scoring_overview(date, venue):
+    """予測と実結果を突き合わせた的中率概要を表示する"""
+    import json
+    from pathlib import Path
+    import numpy as np
+
+    pred_dir   = Path("data/prediction_logs")
+    result_dir = Path("data/race_results")
+
+    preds = {}
+    if pred_dir.exists():
+        for p in pred_dir.glob("*.json"):
+            try:
+                with open(p, encoding="utf-8") as f:
+                    preds[p.stem] = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                continue
+
+    results = {}
+    if result_dir.exists():
+        for r in result_dir.glob("*.json"):
+            try:
+                with open(r, encoding="utf-8") as f:
+                    results[r.stem] = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                continue
+
+    matched = [(rid, preds[rid], results[rid]) for rid in set(preds) & set(results)]
+
+    if date:
+        matched = [(rid, p, r) for rid, p, r in matched if p.get("race_date") == date]
+    if venue:
+        matched = [(rid, p, r) for rid, p, r in matched if p.get("jyo_code") == venue]
+
+    if not matched:
+        click.echo("集計対象データなし")
+        return
+
+    n_correct = 0
+    rank_sum = 0.0
+    n_with_rank = 0
+    top3 = 0
+
+    for _, pred, result in matched:
+        proba = pred.get("win_probabilities") or pred.get("proba") or []
+        true_winner = result.get("true_winner")
+        if not proba or true_winner is None:
+            continue
+        arr   = np.array(proba)
+        order = np.argsort(arr)[::-1]
+        predicted = int(order[0]) + 1
+        if predicted == true_winner:
+            n_correct += 1
+        winner_idx = true_winner - 1
+        if 0 <= winner_idx < len(arr):
+            rank = int(np.where(order == winner_idx)[0][0]) + 1
+            rank_sum += rank
+            n_with_rank += 1
+            if rank <= 3:
+                top3 += 1
+
+    n = len(matched)
+    filter_str = ""
+    if date:
+        filter_str += f"  日付: {date}"
+    if venue:
+        filter_str += f"  場: {venue}"
+
+    click.echo(f"\n{'='*50}")
+    click.echo(" 予測スコアリング概要" + (f" [{filter_str.strip()}]" if filter_str else ""))
+    click.echo(f"{'='*50}")
+    click.echo(f" 予測ログ数  : {len(preds)}")
+    click.echo(f" 結果ログ数  : {len(results)}")
+    click.echo(f" 突き合わせ数: {n}")
+    click.echo(f" 的中数      : {n_correct}")
+    click.echo(f" 1着的中率   : {n_correct/n*100:.1f}%" if n else " 1着的中率   : N/A")
+    click.echo(f" Top-3率     : {top3/n_with_rank*100:.1f}%" if n_with_rank else " Top-3率     : N/A")
+    click.echo(f" 平均予測順位: {rank_sum/n_with_rank:.2f}" if n_with_rank else " 平均予測順位: N/A")
+    click.echo("=" * 50)
+
+
+@scoring.command("race")
+@click.argument("race_id")
+def scoring_race(race_id):
+    """指定レースの予測と実結果を表示する
+
+    \b
+    例:
+      python -m app.cli scoring race 20260420_01_R01
+    """
+    import json
+    import numpy as np
+    from pathlib import Path
+
+    pred_path   = Path("data/prediction_logs") / f"{race_id}.json"
+    result_path = Path("data/race_results")    / f"{race_id}.json"
+
+    pred   = None
+    result = None
+
+    if pred_path.exists():
+        try:
+            with open(pred_path, encoding="utf-8") as f:
+                pred = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    if result_path.exists():
+        try:
+            with open(result_path, encoding="utf-8") as f:
+                result = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    if pred is None and result is None:
+        click.secho(f"レースID {race_id} の予測も結果も見つかりません", fg="red", err=True)
+        sys.exit(1)
+
+    click.echo(f"\n{'='*50}")
+    click.echo(f" レース: {race_id}")
+    click.echo(f"{'='*50}")
+    click.echo(f" 予測ログ: {'あり' if pred else 'なし'}")
+    click.echo(f" 結果ログ: {'あり' if result else 'なし'}")
+
+    if pred and result:
+        proba = pred.get("win_probabilities") or pred.get("proba") or []
+        true_winner = result.get("true_winner")
+        if proba and true_winner is not None:
+            arr   = np.array(proba)
+            order = np.argsort(arr)[::-1]
+            predicted = int(order[0]) + 1
+            is_correct = predicted == true_winner
+            winner_idx = true_winner - 1
+            rank = int(np.where(order == winner_idx)[0][0]) + 1 if 0 <= winner_idx < len(arr) else None
+
+            click.echo(f" 予測1位   : {predicted}号艇  (確率: {arr[order[0]]*100:.1f}%)")
+            click.echo(f" 実際の1着 : {true_winner}号艇")
+            if rank:
+                click.echo(f" 正解艇の予測順位: {rank}位")
+            color = "green" if is_correct else "red"
+            label = "✓ 的中" if is_correct else "✗ 外れ"
+            click.secho(f" 結果      : {label}", fg=color)
+    elif pred:
+        proba = pred.get("win_probabilities") or pred.get("proba") or []
+        if proba:
+            arr   = __import__("numpy").array(proba)
+            order = arr.argsort()[::-1]
+            click.echo(f" 予測1位   : {int(order[0])+1}号艇  (確率: {arr[order[0]]*100:.1f}%)")
+        click.echo(" 結果未記録")
+    elif result:
+        click.echo(f" 実際の1着 : {result.get('true_winner')}号艇")
+        click.echo(" 予測なし")
+
+    click.echo("=" * 50)
+
+
+# ============================================================
 # エントリーポイント
 # ============================================================
 

--- a/project/tests/test_cli.py
+++ b/project/tests/test_cli.py
@@ -307,6 +307,135 @@ class TestShadowStats:
 # エントリー / バージョン
 # ============================================================
 
+# ============================================================
+# scoring グループ
+# ============================================================
+
+def _write_pred(path: Path, race_id: str, win_proba: list,
+                jyo_code: str = "01", race_date: str = "20260420") -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    record = {
+        "race_id":           race_id,
+        "jyo_code":          jyo_code,
+        "race_date":         race_date,
+        "win_probabilities": win_proba,
+    }
+    (path / f"{race_id}.json").write_text(
+        json.dumps(record, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+def _write_res(path: Path, race_id: str, true_winner: int) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    record = {"race_id": race_id, "true_winner": true_winner}
+    (path / f"{race_id}.json").write_text(
+        json.dumps(record, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+class TestScoringCli:
+    def test_overview_no_data(self, runner, tmp_path, monkeypatch):
+        """予測・結果データなしのとき 'データなし' が表示されること"""
+        monkeypatch.chdir(tmp_path)
+        from app.cli import cli
+        result = runner.invoke(cli, ["scoring", "overview"])
+        assert result.exit_code == 0
+        assert "データなし" in result.output
+
+    def test_overview_with_data(self, runner, tmp_path, monkeypatch):
+        """予測と結果が揃っているとき的中率が表示されること"""
+        monkeypatch.chdir(tmp_path)
+        pred_dir   = tmp_path / "data" / "prediction_logs"
+        result_dir = tmp_path / "data" / "race_results"
+        _write_pred(pred_dir, "r1", [0.5, 0.1, 0.1, 0.1, 0.1, 0.1])
+        _write_pred(pred_dir, "r2", [0.5, 0.1, 0.1, 0.1, 0.1, 0.1])
+        _write_res(result_dir, "r1", true_winner=1)   # 的中
+        _write_res(result_dir, "r2", true_winner=3)   # 外れ
+
+        from app.cli import cli
+        result = runner.invoke(cli, ["scoring", "overview"])
+        assert result.exit_code == 0
+        assert "突き合わせ数" in result.output
+        assert "50.0%" in result.output
+
+    def test_overview_date_filter(self, runner, tmp_path, monkeypatch):
+        """--date フィルターが動作すること"""
+        monkeypatch.chdir(tmp_path)
+        pred_dir   = tmp_path / "data" / "prediction_logs"
+        result_dir = tmp_path / "data" / "race_results"
+        _write_pred(pred_dir, "r1", [0.5, 0.1, 0.1, 0.1, 0.1, 0.1], race_date="20260420")
+        _write_pred(pred_dir, "r2", [0.5, 0.1, 0.1, 0.1, 0.1, 0.1], race_date="20260421")
+        _write_res(result_dir, "r1", true_winner=1)
+        _write_res(result_dir, "r2", true_winner=1)
+
+        from app.cli import cli
+        result = runner.invoke(cli, ["scoring", "overview", "--date", "20260420"])
+        assert result.exit_code == 0
+        assert "20260420" in result.output
+
+    def test_overview_venue_filter(self, runner, tmp_path, monkeypatch):
+        """--venue フィルターが動作すること"""
+        monkeypatch.chdir(tmp_path)
+        pred_dir   = tmp_path / "data" / "prediction_logs"
+        result_dir = tmp_path / "data" / "race_results"
+        _write_pred(pred_dir, "r1", [0.5, 0.1, 0.1, 0.1, 0.1, 0.1], jyo_code="06")
+        _write_res(result_dir, "r1", true_winner=1)
+
+        from app.cli import cli
+        result = runner.invoke(cli, ["scoring", "overview", "--venue", "06"])
+        assert result.exit_code == 0
+        assert "06" in result.output
+
+    def test_race_both_present(self, runner, tmp_path, monkeypatch):
+        """予測と結果が両方あるとき照合結果が表示されること"""
+        monkeypatch.chdir(tmp_path)
+        pred_dir   = tmp_path / "data" / "prediction_logs"
+        result_dir = tmp_path / "data" / "race_results"
+        _write_pred(pred_dir, "r_match", [0.5, 0.1, 0.1, 0.1, 0.1, 0.1])
+        _write_res(result_dir, "r_match", true_winner=1)
+
+        from app.cli import cli
+        result = runner.invoke(cli, ["scoring", "race", "r_match"])
+        assert result.exit_code == 0
+        assert "的中" in result.output
+        assert "1号艇" in result.output
+
+    def test_race_miss(self, runner, tmp_path, monkeypatch):
+        """予測1位と実際の1着が異なるとき '外れ' が表示されること"""
+        monkeypatch.chdir(tmp_path)
+        pred_dir   = tmp_path / "data" / "prediction_logs"
+        result_dir = tmp_path / "data" / "race_results"
+        _write_pred(pred_dir, "r_miss", [0.5, 0.1, 0.1, 0.1, 0.1, 0.1])
+        _write_res(result_dir, "r_miss", true_winner=3)
+
+        from app.cli import cli
+        result = runner.invoke(cli, ["scoring", "race", "r_miss"])
+        assert result.exit_code == 0
+        assert "外れ" in result.output
+
+    def test_race_not_found(self, runner, tmp_path, monkeypatch):
+        """存在しない race_id のとき exit_code=1 になること"""
+        monkeypatch.chdir(tmp_path)
+        from app.cli import cli
+        result = runner.invoke(cli, ["scoring", "race", "no_such_race"])
+        assert result.exit_code == 1
+
+    def test_race_prediction_only(self, runner, tmp_path, monkeypatch):
+        """予測のみ（結果未記録）のとき '結果未記録' が表示されること"""
+        monkeypatch.chdir(tmp_path)
+        pred_dir = tmp_path / "data" / "prediction_logs"
+        _write_pred(pred_dir, "r_pred_only", [1/6] * 6)
+
+        from app.cli import cli
+        result = runner.invoke(cli, ["scoring", "race", "r_pred_only"])
+        assert result.exit_code == 0
+        assert "結果未記録" in result.output
+
+
+# ============================================================
+# エントリー / バージョン
+# ============================================================
+
 class TestCliEntry:
     def test_version_flag(self, runner):
         """--version オプションが動作すること"""
@@ -320,3 +449,4 @@ class TestCliEntry:
         from app.cli import cli
         result = runner.invoke(cli, ["--help"])
         assert result.exit_code == 0
+        assert "scoring" in result.output


### PR DESCRIPTION
- app/cli.py: add `scoring` group with `overview` and `race` subcommands; cross-references data/prediction_logs + data/race_results locally without requiring the API server to be running
- Makefile: add `daily`, `daily-live`, `auto-retrain`, `scoring`, `ci`, `ci-full` targets; update help listing for new targets
- tests/test_cli.py: 8 new tests covering scoring overview (no-data, with-data, date/venue filter), scoring race (hit, miss, not-found, prediction-only), and help output now asserts "scoring" group is listed

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy