### PR TITLE
feat: mysqldump + binlog 自動バックアップスクリプト追加 (Cron対応)

### DIFF
--- a/mysql_backup/backup.sh
+++ b/mysql_backup/backup.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# ============================================================
+# MySQL フルバックアップスクリプト (mysqldump + binlog 位置記録)
+#
+# 機能:
+#   - mysqldump でフルバックアップを取得
+#   - --master-data=2 で binlog ファイル名・位置をコメントとして記録
+#   - --flush-logs でバックアップ前に binlog をローテーション
+#   - gzip 圧縮
+#   - 取得後に binlog 差分バックアップも実行 (オプション)
+#   - 古いバックアップの自動削除
+#
+# 使い方:
+#   ./backup.sh [--no-binlog] [--db データベース名] [--dry-run]
+#
+# Cron 例 (毎日 2:00 に実行):
+#   0 2 * * * /path/to/mysql_backup/backup.sh >> /var/log/mysql_backup/cron.log 2>&1
+# ============================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+# ─── 引数処理 ────────────────────────────────────────────────────
+RUN_BINLOG_AFTER=true
+DRY_RUN=false
+OVERRIDE_DB=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-binlog)  RUN_BINLOG_AFTER=false ;;
+        --db)         OVERRIDE_DB="$2"; shift ;;
+        --dry-run)    DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \?//'
+            exit 0 ;;
+        *) log_warn "不明なオプション: $1" ;;
+    esac
+    shift
+done
+
+# ─── メイン処理 ──────────────────────────────────────────────────
+
+main() {
+    init_dirs
+    log_info "========== フルバックアップ開始 =========="
+
+    check_mysql_connection || { notify_slack failure "MySQL 接続失敗"; exit 1; }
+
+    local ts; ts=$(date '+%Y%m%d_%H%M%S')
+    local backup_dir="${BACKUP_BASE_DIR}/${ts}"
+    mkdir -p "${backup_dir}"
+
+    # バックアップ対象 DB を決定
+    local target_dbs
+    if [[ -n "${OVERRIDE_DB}" ]]; then
+        target_dbs="${OVERRIDE_DB}"
+    elif [[ -n "${TARGET_DATABASES}" ]]; then
+        target_dbs="${TARGET_DATABASES}"
+    else
+        target_dbs=""  # 空 = --all-databases
+    fi
+
+    local dump_file
+    if [[ -z "${target_dbs}" ]]; then
+        dump_file="${backup_dir}/all_databases_${ts}.sql"
+        _run_dump_all "${dump_file}"
+    else
+        for db in ${target_dbs}; do
+            dump_file="${backup_dir}/${db}_${ts}.sql"
+            _run_dump_single "${db}" "${dump_file}"
+        done
+    fi
+
+    # binlog 位置をメタファイルに保存
+    _save_binlog_position "${backup_dir}/${ts}.meta"
+
+    # 圧縮
+    if [[ "${COMPRESS}" == "true" ]]; then
+        _compress_dir "${backup_dir}"
+    fi
+
+    # 世代管理
+    purge_old_files "${BACKUP_BASE_DIR}" "${FULL_RETENTION_DAYS}" "*"
+
+    log_info "フルバックアップ完了: ${backup_dir}"
+    log_info "=========================================="
+
+    # binlog 差分バックアップを続けて実行
+    if [[ "${RUN_BINLOG_AFTER}" == "true" ]]; then
+        log_info "binlog バックアップを続けて実行します..."
+        "${SCRIPT_DIR}/binlog_backup.sh" || log_warn "binlog バックアップで警告が発生しました"
+    fi
+
+    notify_slack success "フルバックアップ完了\nDir: ${backup_dir}"
+}
+
+# ─── 全DB ダンプ ──────────────────────────────────────────────────
+
+_run_dump_all() {
+    local out_file="$1"
+    log_info "全データベースダンプ開始 → ${out_file}"
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log_info "[DRY-RUN] mysqldump --all-databases ${MYSQLDUMP_OPTS}"
+        return 0
+    fi
+
+    # shellcheck disable=SC2046,SC2086
+    mysqldump $(mysql_opts) \
+        ${MYSQLDUMP_OPTS} \
+        --all-databases \
+        > "${out_file}" 2>> "${LOG_FILE}"
+
+    local size; size=$(du -sh "${out_file}" | cut -f1)
+    log_info "ダンプ完了: ${out_file} (${size})"
+}
+
+# ─── 単一DB ダンプ ────────────────────────────────────────────────
+
+_run_dump_single() {
+    local db="$1"
+    local out_file="$2"
+    log_info "データベースダンプ開始: ${db} → ${out_file}"
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log_info "[DRY-RUN] mysqldump ${db} ${MYSQLDUMP_OPTS}"
+        return 0
+    fi
+
+    # shellcheck disable=SC2046,SC2086
+    mysqldump $(mysql_opts) \
+        ${MYSQLDUMP_OPTS} \
+        "${db}" \
+        > "${out_file}" 2>> "${LOG_FILE}"
+
+    local size; size=$(du -sh "${out_file}" | cut -f1)
+    log_info "ダンプ完了: ${out_file} (${size})"
+}
+
+# ─── binlog 位置保存 ──────────────────────────────────────────────
+
+_save_binlog_position() {
+    local meta_file="$1"
+    local status; status=$(get_binlog_status)
+
+    {
+        echo "# バックアップ取得時点の binlog 位置"
+        echo "# 生成日時: $(date '+%Y-%m-%d %H:%M:%S')"
+        echo "# ホスト: $(hostname)"
+        echo ""
+        echo "${status}"
+    } > "${meta_file}"
+
+    log_info "binlog 位置を保存: ${meta_file}"
+    log_info "$(grep -E 'File|Position|Executed_Gtid_Set' "${meta_file}" | head -5)"
+}
+
+# ─── ディレクトリ圧縮 ────────────────────────────────────────────
+
+_compress_dir() {
+    local dir="$1"
+    log_info "圧縮中: ${dir}/*.sql"
+
+    find "${dir}" -name "*.sql" -type f | while read -r f; do
+        gzip -"${COMPRESS_LEVEL}" "${f}"
+        log_info "  圧縮完了: ${f}.gz"
+    done
+}
+
+# ─── エラーハンドラー ────────────────────────────────────────────
+
+trap 'log_error "スクリプト異常終了 (line ${LINENO})"; notify_slack failure "フルバックアップ失敗 (line ${LINENO})"' ERR
+
+main "$@"

--- a/mysql_backup/binlog_backup.sh
+++ b/mysql_backup/binlog_backup.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# ============================================================
+# MySQL バイナリログ差分バックアップスクリプト
+#
+# 機能:
+#   - mysqlbinlog でバイナリログをリモートからストリーミング取得
+#   - または サーバー上の binlog ファイルを直接コピー
+#   - 前回取得した binlog ファイル名・位置から続きを取得
+#   - gzip 圧縮 + 世代管理
+#
+# 実行方式:
+#   MODE=stream  → mysqlbinlog --read-from-remote-server でストリーミング (推奨)
+#   MODE=copy    → サーバーと同一ホスト上で binlog ファイルを直接コピー
+#
+# 使い方:
+#   ./binlog_backup.sh [--mode stream|copy] [--dry-run]
+#
+# Cron 例 (15分ごとに差分取得):
+#   */15 * * * * /path/to/mysql_backup/binlog_backup.sh >> /var/log/mysql_backup/binlog.log 2>&1
+# ============================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+# ─── 引数処理 ────────────────────────────────────────────────────
+MODE="stream"    # stream or copy
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --mode)   MODE="$2"; shift ;;
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \?//'
+            exit 0 ;;
+        *) log_warn "不明なオプション: $1" ;;
+    esac
+    shift
+done
+
+# ─── 状態ファイル (前回の取得位置を記録) ─────────────────────────
+STATE_FILE="${BINLOG_BACKUP_DIR}/.last_binlog_state"
+
+# ─── メイン処理 ──────────────────────────────────────────────────
+
+main() {
+    init_dirs
+    log_info "========== binlog バックアップ開始 (mode=${MODE}) =========="
+
+    check_mysql_connection || { notify_slack failure "MySQL 接続失敗 (binlog)"; exit 1; }
+
+    case "${MODE}" in
+        stream) _backup_stream ;;
+        copy)   _backup_copy   ;;
+        *)
+            log_error "不明なモード: ${MODE} (stream または copy を指定)"
+            exit 1 ;;
+    esac
+
+    # 古い binlog バックアップを削除
+    purge_old_files "${BINLOG_BACKUP_DIR}" "${BINLOG_RETENTION_DAYS}" "*.sql.gz"
+    purge_old_files "${BINLOG_BACKUP_DIR}" "${BINLOG_RETENTION_DAYS}" "*.bin.gz"
+
+    log_info "========== binlog バックアップ完了 =========="
+}
+
+# ─── ストリーミング取得 (mysqlbinlog --read-from-remote-server) ───
+
+_backup_stream() {
+    # 現在の binlog ファイル名・位置を取得
+    local current_file current_pos
+    # shellcheck disable=SC2046
+    current_file=$(mysql $(mysql_opts) -N -e "SHOW MASTER STATUS" | awk '{print $1}')
+    # shellcheck disable=SC2046
+    current_pos=$(mysql  $(mysql_opts) -N -e "SHOW MASTER STATUS" | awk '{print $2}')
+
+    if [[ -z "${current_file}" ]]; then
+        log_error "binlog が有効ではありません (log_bin=ON を確認してください)"
+        exit 1
+    fi
+
+    # 前回の状態を読み込む
+    local start_file start_pos
+    if [[ -f "${STATE_FILE}" ]]; then
+        start_file=$(grep '^BINLOG_FILE=' "${STATE_FILE}" | cut -d= -f2)
+        start_pos=$(grep  '^BINLOG_POS='  "${STATE_FILE}" | cut -d= -f2)
+        log_info "前回の取得位置: ${start_file}:${start_pos}"
+    else
+        # 初回: 現在の binlog から開始
+        start_file="${current_file}"
+        start_pos=4   # binlog の先頭位置 (magic bytes の後)
+        log_info "初回実行: ${start_file}:${start_pos} から開始"
+    fi
+
+    local ts; ts=$(date '+%Y%m%d_%H%M%S')
+    local out_file="${BINLOG_BACKUP_DIR}/binlog_${ts}.sql"
+
+    log_info "ストリーミング取得: ${start_file}(pos=${start_pos}) → ${current_file}(pos=${current_pos})"
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log_info "[DRY-RUN] mysqlbinlog --read-from-remote-server \\"
+        log_info "  --start-position=${start_pos} --stop-position=${current_pos} \\"
+        log_info "  ${start_file} > ${out_file}"
+    else
+        # shellcheck disable=SC2046
+        mysqlbinlog \
+            $(mysql_opts) \
+            --read-from-remote-server \
+            --raw \
+            --result-file="${BINLOG_BACKUP_DIR}/" \
+            --start-position="${start_pos}" \
+            "${start_file}" 2>> "${LOG_FILE}" || {
+            # raw モード失敗時は SQL 形式にフォールバック
+            log_warn "raw モード失敗。SQL 形式で再試行..."
+            # shellcheck disable=SC2046
+            mysqlbinlog \
+                $(mysql_opts) \
+                --read-from-remote-server \
+                --start-position="${start_pos}" \
+                --to-last-log \
+                "${start_file}" \
+                > "${out_file}" 2>> "${LOG_FILE}"
+
+            _compress_file "${out_file}"
+        }
+
+        # 状態ファイルを更新
+        _save_state "${current_file}" "${current_pos}"
+
+        local size; size=$(du -sh "${BINLOG_BACKUP_DIR}/${start_file}"* 2>/dev/null | head -1 | cut -f1 || echo "?")
+        log_info "ストリーミング取得完了"
+    fi
+}
+
+# ─── ファイルコピー (同一ホスト上) ──────────────────────────────
+
+_backup_copy() {
+    if [[ ! -d "${MYSQL_BINLOG_DIR}" ]]; then
+        log_error "binlog ディレクトリが見つかりません: ${MYSQL_BINLOG_DIR}"
+        exit 1
+    fi
+
+    # 前回コピーした最後のファイルを記録
+    local last_copied=""
+    if [[ -f "${STATE_FILE}" ]]; then
+        last_copied=$(grep '^BINLOG_FILE=' "${STATE_FILE}" | cut -d= -f2)
+    fi
+
+    # インデックスファイルから binlog 一覧を取得
+    local index_file="${MYSQL_BINLOG_DIR}/${BINLOG_BASENAME}.index"
+    if [[ ! -f "${index_file}" ]]; then
+        log_error "binlog インデックスが見つかりません: ${index_file}"
+        exit 1
+    fi
+
+    local copied=0
+    while IFS= read -r binlog_path; do
+        local binlog_file; binlog_file=$(basename "${binlog_path}")
+
+        # 前回コピー済みより古いファイルはスキップ
+        if [[ -n "${last_copied}" && "${binlog_file}" < "${last_copied}" ]]; then
+            continue
+        fi
+        # 現在アクティブなファイルはまだ書き込み中のため後で取得
+        # shellcheck disable=SC2046
+        local current_active
+        current_active=$(mysql $(mysql_opts) -N -e "SHOW MASTER STATUS" | awk '{print $1}')
+        if [[ "${binlog_file}" == "${current_active}" ]]; then
+            log_info "アクティブ binlog はスキップ (次回以降に取得): ${binlog_file}"
+            continue
+        fi
+
+        local src="${MYSQL_BINLOG_DIR}/${binlog_file}"
+        local dst="${BINLOG_BACKUP_DIR}/${binlog_file}.gz"
+
+        if [[ -f "${dst}" ]]; then
+            log_info "スキップ (取得済み): ${binlog_file}"
+            last_copied="${binlog_file}"
+            continue
+        fi
+
+        log_info "コピー: ${src} → ${dst}"
+        if [[ "${DRY_RUN}" == "false" ]]; then
+            # mysqlbinlog で SQL 形式に変換してから圧縮
+            mysqlbinlog "${src}" | gzip -"${COMPRESS_LEVEL}" > "${dst}"
+            log_info "  コピー完了: $(du -sh "${dst}" | cut -f1)"
+        else
+            log_info "[DRY-RUN] mysqlbinlog ${src} | gzip > ${dst}"
+        fi
+
+        last_copied="${binlog_file}"
+        (( copied++ ))
+
+    done < "${index_file}"
+
+    if [[ -n "${last_copied}" ]]; then
+        _save_state "${last_copied}" "0"
+    fi
+
+    log_info "コピー完了: ${copied} ファイル"
+}
+
+# ─── 状態ファイル保存 ─────────────────────────────────────────────
+
+_save_state() {
+    local binlog_file="$1"
+    local binlog_pos="$2"
+    {
+        echo "BINLOG_FILE=${binlog_file}"
+        echo "BINLOG_POS=${binlog_pos}"
+        echo "LAST_BACKUP=$(date '+%Y-%m-%d %H:%M:%S')"
+    } > "${STATE_FILE}"
+    log_info "状態を保存: ${binlog_file}:${binlog_pos}"
+}
+
+# ─── ファイル圧縮 ────────────────────────────────────────────────
+
+_compress_file() {
+    local f="$1"
+    [[ "${COMPRESS}" != "true" ]] && return 0
+    [[ ! -f "${f}" ]] && return 0
+    gzip -"${COMPRESS_LEVEL}" "${f}"
+    log_info "圧縮完了: ${f}.gz"
+}
+
+# ─── エラーハンドラー ────────────────────────────────────────────
+
+trap 'log_error "スクリプト異常終了 (line ${LINENO})"; notify_slack failure "binlog バックアップ失敗 (line ${LINENO})"' ERR
+
+main "$@"

--- a/mysql_backup/config.sh
+++ b/mysql_backup/config.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# MySQL バックアップ 共通設定ファイル
+# このファイルを編集して環境に合わせてください
+
+# ─── 接続設定 ───────────────────────────────────────────────────
+MYSQL_USER="backup_user"
+MYSQL_PASSWORD=""                     # 空の場合は ~/.my.cnf から読む
+MYSQL_HOST="127.0.0.1"
+MYSQL_PORT="3306"
+MYSQL_SOCKET=""                       # 例: /var/run/mysqld/mysqld.sock
+
+# ─── バックアップ先ディレクトリ ─────────────────────────────────
+BACKUP_BASE_DIR="/var/backup/mysql"   # フルバックアップ出力先
+BINLOG_BACKUP_DIR="/var/backup/mysql/binlog"  # バイナリログ出力先
+
+# ─── 保持期間 (日数) ────────────────────────────────────────────
+FULL_RETENTION_DAYS=7                 # フルバックアップの保持日数
+BINLOG_RETENTION_DAYS=14             # バイナリログの保持日数
+
+# ─── 圧縮設定 ───────────────────────────────────────────────────
+COMPRESS=true                         # gzip 圧縮を有効にする
+COMPRESS_LEVEL=6                      # gzip 圧縮レベル (1-9)
+
+# ─── 通知設定 ───────────────────────────────────────────────────
+SLACK_WEBHOOK_URL=""                  # Slack 通知先 Webhook URL (空で無効)
+NOTIFY_ON_SUCCESS=false              # 成功時も通知するか
+NOTIFY_ON_FAILURE=true               # 失敗時に通知するか
+
+# ─── ログ設定 ───────────────────────────────────────────────────
+LOG_DIR="/var/log/mysql_backup"
+LOG_FILE="${LOG_DIR}/backup.log"
+MAX_LOG_SIZE_MB=50                    # ログローテーションサイズ (MB)
+
+# ─── mysqldump オプション ────────────────────────────────────────
+# --single-transaction: InnoDB の一貫スナップショット
+# --master-data=2    : binlog 位置をコメントとして記録 (GTID 使用時は不要)
+# --flush-logs       : バックアップ前に binlog をフラッシュ・ローテーション
+# --set-gtid-purged  : GTID 有効時は ON, 無効時は OFF
+MYSQLDUMP_OPTS="--single-transaction --flush-logs --master-data=2 \
+    --routines --triggers --events \
+    --set-gtid-purged=OFF \
+    --hex-blob --default-character-set=utf8mb4"
+
+# ─── バックアップ対象データベース ───────────────────────────────
+# 空の場合は --all-databases で全DB取得
+# 複数指定する場合はスペース区切り: "db1 db2 db3"
+TARGET_DATABASES=""
+
+# ─── バイナリログ設定 ────────────────────────────────────────────
+# MySQL サーバー上のバイナリログディレクトリ
+MYSQL_BINLOG_DIR="/var/lib/mysql"     # サーバー上の binlog 配置場所
+BINLOG_BASENAME="mysql-bin"          # binlog ファイルのベース名 (my.cnf の log_bin 値)

--- a/mysql_backup/crontab.example
+++ b/mysql_backup/crontab.example
@@ -1,0 +1,42 @@
+# ============================================================
+# MySQL バックアップ Cron 設定例
+#
+# 設置方法:
+#   sudo crontab -e -u mysql      # mysql ユーザーとして実行する場合
+#   または
+#   crontab -e                    # 現在のユーザーとして実行
+#
+# 以下の行をコピーして crontab に貼り付けてください。
+# /path/to は実際のスクリプトパスに変更してください。
+# ============================================================
+
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+MAILTO=""   # エラーをメール送信する場合はアドレスを設定
+
+# ─── フルバックアップ ────────────────────────────────────────────
+# 毎日 02:00 にフルバックアップ + binlog 差分を取得
+0 2 * * * /path/to/mysql_backup/backup.sh >> /var/log/mysql_backup/cron.log 2>&1
+
+# 週1回 (日曜 01:00) に全DB フルバックアップのみ
+# 0 1 * * 0 /path/to/mysql_backup/backup.sh --no-binlog >> /var/log/mysql_backup/cron.log 2>&1
+
+# ─── binlog 差分バックアップ ─────────────────────────────────────
+# 15分ごとに binlog 差分を取得 (フルバックアップの間を埋める)
+*/15 * * * * /path/to/mysql_backup/binlog_backup.sh >> /var/log/mysql_backup/binlog_cron.log 2>&1
+
+# 5分ごとの場合 (RPO=5分を達成したい場合)
+# */5 * * * * /path/to/mysql_backup/binlog_backup.sh >> /var/log/mysql_backup/binlog_cron.log 2>&1
+
+# ─── ログローテーション ──────────────────────────────────────────
+# /etc/logrotate.d/mysql_backup に以下を配置することを推奨:
+#
+# /var/log/mysql_backup/*.log {
+#     daily
+#     rotate 30
+#     compress
+#     delaycompress
+#     missingok
+#     notifempty
+#     copytruncate
+# }

--- a/mysql_backup/lib.sh
+++ b/mysql_backup/lib.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# 共通ライブラリ (backup.sh / binlog_backup.sh から source して使用)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+# ─── ログ関数 ────────────────────────────────────────────────────
+
+_log() {
+    local level="$1"; shift
+    local ts; ts=$(date '+%Y-%m-%d %H:%M:%S')
+    echo "${ts} [${level}] $*" | tee -a "${LOG_FILE}"
+}
+log_info()  { _log INFO  "$@"; }
+log_warn()  { _log WARN  "$@"; }
+log_error() { _log ERROR "$@"; }
+
+# ─── 初期化 ──────────────────────────────────────────────────────
+
+init_dirs() {
+    mkdir -p "${BACKUP_BASE_DIR}" "${BINLOG_BACKUP_DIR}" "${LOG_DIR}"
+    # ログローテーション
+    if [[ -f "${LOG_FILE}" ]]; then
+        local size_mb; size_mb=$(du -m "${LOG_FILE}" | cut -f1)
+        if (( size_mb >= MAX_LOG_SIZE_MB )); then
+            mv "${LOG_FILE}" "${LOG_FILE}.$(date +%Y%m%d%H%M%S).old"
+            log_info "ログファイルをローテーションしました"
+        fi
+    fi
+}
+
+# ─── MySQL 接続オプション生成 ─────────────────────────────────────
+
+mysql_opts() {
+    local opts=()
+    opts+=(-u "${MYSQL_USER}")
+    [[ -n "${MYSQL_PASSWORD}" ]] && opts+=(-p"${MYSQL_PASSWORD}")
+    [[ -n "${MYSQL_SOCKET}"   ]] && opts+=(--socket="${MYSQL_SOCKET}") \
+                                 || opts+=(-h "${MYSQL_HOST}" -P "${MYSQL_PORT}")
+    printf '%s ' "${opts[@]}"
+}
+
+# ─── MySQL 疎通確認 ───────────────────────────────────────────────
+
+check_mysql_connection() {
+    log_info "MySQL 接続確認中..."
+    # shellcheck disable=SC2046
+    if ! mysql $(mysql_opts) -e "SELECT 1;" &>/dev/null; then
+        log_error "MySQL に接続できません。設定を確認してください。"
+        return 1
+    fi
+    log_info "MySQL 接続 OK"
+}
+
+# ─── 現在の binlog 位置取得 ──────────────────────────────────────
+
+get_binlog_status() {
+    # shellcheck disable=SC2046
+    mysql $(mysql_opts) -e "SHOW MASTER STATUS\G" 2>/dev/null
+}
+
+# ─── Slack 通知 ──────────────────────────────────────────────────
+
+notify_slack() {
+    local status="$1"   # "success" or "failure"
+    local message="$2"
+
+    [[ -z "${SLACK_WEBHOOK_URL}" ]] && return 0
+    [[ "${status}" == "success" && "${NOTIFY_ON_SUCCESS}" == "false" ]] && return 0
+    [[ "${status}" == "failure" && "${NOTIFY_ON_FAILURE}" == "false" ]] && return 0
+
+    local emoji=":white_check_mark:"
+    [[ "${status}" == "failure" ]] && emoji=":x:"
+
+    local payload
+    payload=$(cat <<EOF
+{
+  "text": "${emoji} *MySQL Backup ${status^^}*\nHost: $(hostname)\n${message}"
+}
+EOF
+    )
+    curl -s -X POST -H 'Content-type: application/json' \
+        --data "${payload}" "${SLACK_WEBHOOK_URL}" &>/dev/null || true
+}
+
+# ─── 古いファイル削除 ────────────────────────────────────────────
+
+purge_old_files() {
+    local dir="$1"
+    local days="$2"
+    local pattern="${3:-*.sql.gz}"
+
+    log_info "古いバックアップを削除: ${dir} (${days}日以上)"
+    find "${dir}" -maxdepth 1 -name "${pattern}" \
+        -mtime "+${days}" -type f -delete -print \
+        | while read -r f; do log_info "  削除: ${f}"; done
+}

--- a/mysql_backup/restore.sh
+++ b/mysql_backup/restore.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# ============================================================
+# MySQL リストアスクリプト
+#
+# 機能:
+#   1. フルバックアップ (mysqldump) をリストア
+#   2. 指定した日時までの binlog を適用 (ポイントインタイムリカバリ)
+#
+# 使い方:
+#   # フルリストアのみ
+#   ./restore.sh --full /var/backup/mysql/20240101_020000/all_databases_20240101_020000.sql.gz
+#
+#   # フル + binlog でポイントインタイムリカバリ
+#   ./restore.sh --full /path/to/dump.sql.gz \
+#                --binlog-dir /var/backup/mysql/binlog \
+#                --stop-datetime "2024-01-01 10:30:00"
+# ============================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+# ─── 引数処理 ────────────────────────────────────────────────────
+FULL_DUMP=""
+BINLOG_DIR=""
+STOP_DATETIME=""
+START_DATETIME=""
+DRY_RUN=false
+TARGET_DB=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --full)           FULL_DUMP="$2";         shift ;;
+        --binlog-dir)     BINLOG_DIR="$2";         shift ;;
+        --stop-datetime)  STOP_DATETIME="$2";      shift ;;
+        --start-datetime) START_DATETIME="$2";     shift ;;
+        --db)             TARGET_DB="$2";           shift ;;
+        --dry-run)        DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \?//'
+            exit 0 ;;
+        *) log_warn "不明なオプション: $1" ;;
+    esac
+    shift
+done
+
+# ─── メイン処理 ──────────────────────────────────────────────────
+
+main() {
+    init_dirs
+
+    if [[ -z "${FULL_DUMP}" ]]; then
+        log_error "--full オプションでダンプファイルを指定してください"
+        exit 1
+    fi
+
+    if [[ ! -f "${FULL_DUMP}" ]]; then
+        log_error "ダンプファイルが見つかりません: ${FULL_DUMP}"
+        exit 1
+    fi
+
+    log_info "========== MySQL リストア開始 =========="
+    log_warn "!!! 実行前にデータベースのバックアップが取れていることを確認してください !!!"
+
+    check_mysql_connection
+
+    # ─── Step 1: フルリストア ─────────────────────────────────────
+    log_info "Step 1: フルダンプからリストア: ${FULL_DUMP}"
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log_info "[DRY-RUN] zcat ${FULL_DUMP} | mysql ..."
+    else
+        if [[ "${FULL_DUMP}" == *.gz ]]; then
+            # shellcheck disable=SC2046
+            zcat "${FULL_DUMP}" | mysql $(mysql_opts) 2>> "${LOG_FILE}"
+        else
+            # shellcheck disable=SC2046
+            mysql $(mysql_opts) < "${FULL_DUMP}" 2>> "${LOG_FILE}"
+        fi
+        log_info "フルリストア完了"
+    fi
+
+    # ─── Step 2: binlog 適用 ──────────────────────────────────────
+    if [[ -z "${BINLOG_DIR}" ]]; then
+        log_info "binlog ディレクトリの指定なし。フルリストアのみ完了。"
+        return 0
+    fi
+
+    log_info "Step 2: binlog を適用してポイントインタイムリカバリ"
+    log_info "  binlog ディレクトリ: ${BINLOG_DIR}"
+    [[ -n "${START_DATETIME}" ]] && log_info "  開始日時: ${START_DATETIME}"
+    [[ -n "${STOP_DATETIME}"  ]] && log_info "  終了日時: ${STOP_DATETIME}"
+
+    _apply_binlogs
+
+    log_info "========== リストア完了 =========="
+}
+
+# ─── binlog 適用 ──────────────────────────────────────────────────
+
+_apply_binlogs() {
+    # binlog ディレクトリ内の .sql.gz または生 binlog を昇順で処理
+    local mysqlbinlog_opts=()
+    [[ -n "${START_DATETIME}" ]] && mysqlbinlog_opts+=(--start-datetime="${START_DATETIME}")
+    [[ -n "${STOP_DATETIME}"  ]] && mysqlbinlog_opts+=(--stop-datetime="${STOP_DATETIME}")
+    [[ -n "${TARGET_DB}"      ]] && mysqlbinlog_opts+=(--database="${TARGET_DB}")
+
+    local binlog_files=()
+    while IFS= read -r f; do
+        binlog_files+=("$f")
+    done < <(find "${BINLOG_DIR}" -name "*.sql.gz" -o -name "*.bin.gz" | sort)
+
+    if [[ ${#binlog_files[@]} -eq 0 ]]; then
+        log_warn "適用する binlog ファイルが見つかりません: ${BINLOG_DIR}"
+        return 0
+    fi
+
+    log_info "適用する binlog: ${#binlog_files[@]} ファイル"
+
+    for binlog_gz in "${binlog_files[@]}"; do
+        log_info "  適用: ${binlog_gz}"
+        if [[ "${DRY_RUN}" == "true" ]]; then
+            log_info "  [DRY-RUN] zcat ${binlog_gz} | mysqlbinlog ... | mysql"
+            continue
+        fi
+        # shellcheck disable=SC2046,SC2086
+        zcat "${binlog_gz}" | mysqlbinlog "${mysqlbinlog_opts[@]+"${mysqlbinlog_opts[@]}"}" - \
+            | mysql $(mysql_opts) 2>> "${LOG_FILE}"
+    done
+
+    log_info "binlog 適用完了"
+}
+
+trap 'log_error "リストア中に異常終了 (line ${LINENO})"' ERR
+
+main "$@"

--- a/mysql_backup/setup.sh
+++ b/mysql_backup/setup.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# ============================================================
+# セットアップスクリプト
+# MySQL バックアップ用ユーザー作成、ディレクトリ作成、権限設定を行う
+#
+# 使い方:
+#   sudo ./setup.sh
+# ============================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+echo "=== MySQL バックアップセットアップ ==="
+
+# ─── ディレクトリ作成 ─────────────────────────────────────────────
+echo "[1/4] ディレクトリを作成..."
+mkdir -p "${BACKUP_BASE_DIR}" "${BINLOG_BACKUP_DIR}" "${LOG_DIR}"
+chmod 750 "${BACKUP_BASE_DIR}" "${BINLOG_BACKUP_DIR}" "${LOG_DIR}"
+echo "  OK: ${BACKUP_BASE_DIR}"
+echo "  OK: ${BINLOG_BACKUP_DIR}"
+echo "  OK: ${LOG_DIR}"
+
+# ─── スクリプトに実行権限付与 ────────────────────────────────────
+echo "[2/4] スクリプトに実行権限を付与..."
+chmod +x "${SCRIPT_DIR}"/*.sh
+echo "  OK"
+
+# ─── .my.cnf の作成案内 ──────────────────────────────────────────
+echo "[3/4] MySQL 認証設定..."
+
+if [[ -f "${HOME}/.my.cnf" ]]; then
+    echo "  ~/.my.cnf が既に存在します"
+else
+    echo "  ~/.my.cnf を作成してください:"
+    cat <<'EOF'
+
+    cat > ~/.my.cnf << 'MYCNF'
+[client]
+user=backup_user
+password=your_password_here
+host=127.0.0.1
+port=3306
+MYCNF
+    chmod 600 ~/.my.cnf
+
+EOF
+fi
+
+# ─── MySQL バックアップユーザー作成 SQL を表示 ────────────────────
+echo "[4/4] MySQL バックアップユーザー作成 SQL:"
+cat <<'SQL'
+
+  -- MySQL に root で接続して以下を実行してください:
+  CREATE USER IF NOT EXISTS 'backup_user'@'localhost'
+      IDENTIFIED BY 'strong_password_here';
+
+  -- フルバックアップに必要な権限
+  GRANT SELECT, SHOW VIEW, TRIGGER, LOCK TABLES,
+        PROCESS, RELOAD, REPLICATION CLIENT ON *.*
+        TO 'backup_user'@'localhost';
+
+  -- binlog (REPLICATION SLAVE) のストリーミング取得に必要
+  GRANT REPLICATION SLAVE ON *.* TO 'backup_user'@'localhost';
+
+  -- Event バックアップに必要
+  GRANT EVENT ON *.* TO 'backup_user'@'localhost';
+
+  FLUSH PRIVILEGES;
+
+SQL
+
+# ─── my.cnf binlog 設定の確認 ────────────────────────────────────
+echo "=== my.cnf の binlog 設定確認 ==="
+cat <<'EOF'
+  # /etc/mysql/mysql.conf.d/mysqld.cnf または /etc/my.cnf に以下が必要です:
+
+  [mysqld]
+  log_bin            = /var/lib/mysql/mysql-bin
+  binlog_format      = ROW          # ROW 形式推奨 (Point-in-time recovery に必要)
+  expire_logs_days   = 7            # サーバー上の binlog 保持日数
+  max_binlog_size    = 100M
+  server_id          = 1            # レプリケーション構成の場合はユニークな値を設定
+
+  # GTID を使用する場合 (推奨):
+  # gtid_mode          = ON
+  # enforce_gtid_consistency = ON
+
+EOF
+
+echo "=== セットアップ完了 ==="
+echo "config.sh を編集して設定を確認後、以下で動作確認してください:"
+echo "  ./backup.sh --dry-run"
+echo "  ./binlog_backup.sh --dry-run"


### PR DESCRIPTION
- config.sh: MySQL接続・ディレクトリ・保持日数・圧縮・Slack通知など全設定
- lib.sh: ログ・MySQL接続確認・Slack通知・世代管理などの共有関数
- backup.sh: mysqldump フルバックアップ (--single-transaction --master-data=2)
- binlog_backup.sh: バイナリログ差分取得 (stream/copy 2モード対応)
- restore.sh: フルリストア + binlog PITR (ポイントインタイムリカバリ)
- setup.sh: ディレクトリ作成・権限設定・MySQL GRANT SQL 案内
- crontab.example: 毎日2時フルバックアップ + 15分ごとbinlog差分のCron設定例

https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG