### PR TITLE
feat: カバリングインデックス分析エンジンを追加

### DIFF
--- a/rds_analyzer/analyzers/index_analyzer.py
+++ b/rds_analyzer/analyzers/index_analyzer.py
@@ -1,0 +1,336 @@
+"""
+カバリングインデックス分析エンジン
+
+設計意図:
+- クエリパターン（WHERE/ORDER BY/SELECT カラム）と既存インデックスを照合し、
+  カバリングインデックスが効果を発揮する箇所を検出する
+- MySQL/MariaDB と PostgreSQL でインデックス構文が異なるため両方の CREATE 文を生成
+  - MySQL/MariaDB: (key_col1, key_col2, ..., select_col1, select_col2)
+  - PostgreSQL 11+: (key_col1, key_col2) INCLUDE (select_col1, select_col2)
+- rows_examined / rows_returned 比率でフルスキャン度を定量評価
+
+スキャン比率と優先度:
+  >= 1000 かつ 実行頻度 >= 100/日 → critical
+  >= 100  または 高頻度              → high
+  >= 10                              → medium
+  < 10                               → 推奨なし（改善余地が小さい）
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from ..models.index import (
+    CoveringIndexRecommendation,
+    ExistingIndex,
+    IndexAnalysisRequest,
+    IndexAnalysisResult,
+    QueryPattern,
+)
+
+logger = logging.getLogger(__name__)
+
+# スキャン比率の閾値
+_RATIO_CRITICAL = 1000.0
+_RATIO_HIGH = 100.0
+_RATIO_MEDIUM = 10.0
+_FREQ_HIGH = 1000.0   # 1日あたり実行回数
+_FREQ_MEDIUM = 100.0
+
+
+class CoveringIndexAnalyzer:
+    """カバリングインデックス分析エンジン（純粋計算クラス、I/O なし）"""
+
+    def __init__(self) -> None:
+        self._counter = 0
+
+    # ----------------------------------------------------------
+    # パブリック API
+    # ----------------------------------------------------------
+
+    def analyze(self, request: IndexAnalysisRequest) -> IndexAnalysisResult:
+        """
+        クエリパターンと既存インデックスを分析してカバリングインデックス推奨を生成する
+
+        Args:
+            request: 分析リクエスト（クエリ一覧 + 既存インデックス一覧）
+
+        Returns:
+            カバリングインデックス推奨リストを含む分析結果
+        """
+        self._counter = 0
+        recommendations: list[CoveringIndexRecommendation] = []
+        covered_count = 0
+        needing_count = 0
+
+        for query in request.queries:
+            if self._is_covered(query, request.existing_indexes):
+                covered_count += 1
+                logger.debug("クエリ '%s' は既存インデックスでカバー済み", query.query_id or query.table_name)
+                continue
+
+            rec = self._build_recommendation(query, request.engine)
+            if rec:
+                recommendations.append(rec)
+                needing_count += 1
+
+        # 同一テーブルへの複数推奨をマージ
+        recommendations = self._merge_by_table(recommendations)
+
+        return IndexAnalysisResult(
+            instance_id=request.instance_id,
+            analyzed_at=datetime.now(tz=timezone.utc),
+            engine=request.engine,
+            total_queries_analyzed=len(request.queries),
+            queries_already_covered=covered_count,
+            queries_needing_index=needing_count,
+            recommendations=recommendations,
+            estimated_total_improvement_pct=self._total_improvement(recommendations),
+        )
+
+    # ----------------------------------------------------------
+    # カバリング判定
+    # ----------------------------------------------------------
+
+    def _is_covered(self, query: QueryPattern, indexes: list[ExistingIndex]) -> bool:
+        """
+        クエリが既存インデックスでカバーされているか判定する
+
+        カバリング条件:
+          1. filter_columns が index の key_columns のプレフィックスになっている
+          2. クエリが必要とする全カラム (filter + sort + select) が
+             index の key_columns + include_columns に含まれている
+        """
+        needed = set(query.filter_columns + query.sort_columns + query.select_columns)
+        if not needed:
+            return False  # SELECT * など: 判定不能
+
+        for idx in indexes:
+            if idx.table_name != query.table_name:
+                continue
+            available = set(idx.key_columns + idx.include_columns)
+            if needed.issubset(available) and self._is_filter_prefix(
+                query.filter_columns, idx.key_columns
+            ):
+                return True
+        return False
+
+    def _is_filter_prefix(self, filter_cols: list[str], key_cols: list[str]) -> bool:
+        """filter_cols が key_cols の先頭プレフィックスかどうか"""
+        if not filter_cols:
+            return True
+        return len(filter_cols) <= len(key_cols) and all(
+            f == k for f, k in zip(filter_cols, key_cols)
+        )
+
+    # ----------------------------------------------------------
+    # 推奨生成
+    # ----------------------------------------------------------
+
+    def _build_recommendation(
+        self, query: QueryPattern, engine: str
+    ) -> Optional[CoveringIndexRecommendation]:
+        """単一クエリのカバリングインデックス推奨を生成する"""
+        if not query.filter_columns:
+            return None  # WHERE 句なし: インデックスでフルスキャンを解消できない
+
+        ratio = query.avg_rows_examined / max(query.avg_rows_returned, 1.0)
+        if ratio < _RATIO_MEDIUM:
+            return None  # スキャン比率が小さく改善余地が少ない
+
+        # キーカラム: filter → sort → group (重複除去・順序維持)
+        key_cols = _dedup(
+            query.filter_columns + query.sort_columns + query.group_columns
+        )
+        # INCLUDE カラム: SELECT にあり、キーに含まれないもの
+        include_cols = [c for c in query.select_columns if c not in key_cols]
+
+        self._counter += 1
+        idx_name = f"idx_{query.table_name}_covering_{self._counter:03d}"
+
+        # MySQL/MariaDB は INCLUDE 構文がないため全カラムをキーに含める
+        mysql_key_cols = key_cols + include_cols
+
+        improvement_pct = min(95.0, (1.0 - 1.0 / ratio) * 100.0)
+        daily_saved = query.avg_rows_examined * query.execution_count_per_day
+
+        return CoveringIndexRecommendation(
+            recommendation_id=f"idx_{self._counter:03d}",
+            table_name=query.table_name,
+            key_columns=key_cols,
+            include_columns=include_cols,
+            priority=self._priority(ratio, query.execution_count_per_day),
+            reason=self._reason(query, ratio),
+            affected_query_ids=[query.query_id or f"query_{self._counter}"],
+            estimated_scan_ratio=round(ratio, 1),
+            estimated_latency_improvement_pct=round(improvement_pct, 1),
+            estimated_daily_rows_saved=round(daily_saved, 0),
+            create_statement_mysql=self._mysql_create(
+                query.table_name, idx_name, mysql_key_cols
+            ),
+            create_statement_postgresql=self._pg_create(
+                query.table_name, idx_name, key_cols, include_cols, engine
+            ),
+        )
+
+    # ----------------------------------------------------------
+    # 推奨マージ (同一テーブル)
+    # ----------------------------------------------------------
+
+    def _merge_by_table(
+        self, recs: list[CoveringIndexRecommendation]
+    ) -> list[CoveringIndexRecommendation]:
+        """
+        同一テーブルへの推奨をマージする
+
+        マージ条件: filter_columns (= key_columns の先頭) が共通プレフィックスを持つ場合
+        マージ結果: キーカラムは長い方を採用、INCLUDE カラムは和集合を取る
+        """
+        if len(recs) <= 1:
+            return recs
+
+        # テーブル名でグループ化
+        groups: dict[str, list[CoveringIndexRecommendation]] = {}
+        for rec in recs:
+            groups.setdefault(rec.table_name, []).append(rec)
+
+        merged: list[CoveringIndexRecommendation] = []
+        for table, group in groups.items():
+            merged.extend(self._merge_group(table, group))
+
+        return merged
+
+    def _merge_group(
+        self, table: str, group: list[CoveringIndexRecommendation]
+    ) -> list[CoveringIndexRecommendation]:
+        """同一テーブルの推奨グループをマージする"""
+        result: list[CoveringIndexRecommendation] = []
+        processed = [False] * len(group)
+
+        for i, base in enumerate(group):
+            if processed[i]:
+                continue
+            current = base
+            for j, other in enumerate(group[i + 1:], start=i + 1):
+                if processed[j]:
+                    continue
+                common = _common_prefix(current.key_columns, other.key_columns)
+                if not common:
+                    continue
+                current = self._do_merge(table, current, other)
+                processed[j] = True
+            result.append(current)
+            processed[i] = True
+
+        return result
+
+    def _do_merge(
+        self,
+        table: str,
+        a: CoveringIndexRecommendation,
+        b: CoveringIndexRecommendation,
+    ) -> CoveringIndexRecommendation:
+        """2つの推奨をマージする（長いキーを採用、INCLUDEは和集合）"""
+        key_cols = a.key_columns if len(a.key_columns) >= len(b.key_columns) else b.key_columns
+        include_cols = _dedup(a.include_columns + b.include_columns)
+        include_cols = [c for c in include_cols if c not in key_cols]
+
+        _priority_order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+        best_priority = min(
+            [a.priority, b.priority], key=lambda p: _priority_order.get(p, 9)
+        )
+
+        idx_name = f"idx_{table}_covering"
+        mysql_key = key_cols + include_cols
+
+        return CoveringIndexRecommendation(
+            recommendation_id=a.recommendation_id,
+            table_name=table,
+            key_columns=key_cols,
+            include_columns=include_cols,
+            priority=best_priority,
+            reason=f"{a.reason} / {b.reason}",
+            affected_query_ids=_dedup(a.affected_query_ids + b.affected_query_ids),
+            estimated_scan_ratio=max(a.estimated_scan_ratio, b.estimated_scan_ratio),
+            estimated_latency_improvement_pct=max(
+                a.estimated_latency_improvement_pct, b.estimated_latency_improvement_pct
+            ),
+            estimated_daily_rows_saved=a.estimated_daily_rows_saved + b.estimated_daily_rows_saved,
+            create_statement_mysql=self._mysql_create(table, idx_name, mysql_key),
+            create_statement_postgresql=self._pg_create(table, idx_name, key_cols, include_cols, "postgresql"),
+        )
+
+    # ----------------------------------------------------------
+    # 優先度・理由文
+    # ----------------------------------------------------------
+
+    def _priority(self, ratio: float, daily_exec: float) -> str:
+        if ratio >= _RATIO_CRITICAL and daily_exec >= _FREQ_MEDIUM:
+            return "critical"
+        if ratio >= _RATIO_HIGH or (ratio >= _RATIO_MEDIUM and daily_exec >= _FREQ_HIGH):
+            return "high"
+        if ratio >= _RATIO_MEDIUM or daily_exec >= _FREQ_MEDIUM:
+            return "medium"
+        return "low"
+
+    def _reason(self, query: QueryPattern, ratio: float) -> str:
+        parts = [
+            f"`{query.table_name}` で平均 {ratio:.0f}:1 のスキャンが発生 "
+            f"(検査 {query.avg_rows_examined:.0f} 行 / 返却 {query.avg_rows_returned:.0f} 行)",
+        ]
+        if query.avg_latency_ms > 0:
+            parts.append(f"平均レイテンシ {query.avg_latency_ms:.1f} ms")
+        if query.execution_count_per_day > 0:
+            parts.append(f"1日 {query.execution_count_per_day:.0f} 回実行")
+        return " / ".join(parts)
+
+    # ----------------------------------------------------------
+    # CREATE INDEX 文生成
+    # ----------------------------------------------------------
+
+    def _mysql_create(self, table: str, name: str, columns: list[str]) -> str:
+        cols = ", ".join(f"`{c}`" for c in columns)
+        return f"CREATE INDEX `{name}` ON `{table}` ({cols});"
+
+    def _pg_create(
+        self,
+        table: str,
+        name: str,
+        key_cols: list[str],
+        include_cols: list[str],
+        engine: str,
+    ) -> str:
+        keys = ", ".join(f'"{c}"' for c in key_cols)
+        stmt = f'CREATE INDEX "{name}" ON "{table}" ({keys})'
+        # INCLUDE 句は PostgreSQL 11+ のみ対応
+        if include_cols and "postgresql" in engine:
+            incs = ", ".join(f'"{c}"' for c in include_cols)
+            stmt += f" INCLUDE ({incs})"
+        return stmt + ";"
+
+    # ----------------------------------------------------------
+    # 集計ヘルパー
+    # ----------------------------------------------------------
+
+    def _total_improvement(self, recs: list[CoveringIndexRecommendation]) -> float:
+        if not recs:
+            return 0.0
+        return round(
+            sum(r.estimated_latency_improvement_pct for r in recs) / len(recs), 1
+        )
+
+
+# ----------------------------------------------------------
+# モジュールレベルヘルパー
+# ----------------------------------------------------------
+
+def _dedup(lst: list[str]) -> list[str]:
+    """順序を維持しつつ重複を除去する"""
+    return list(dict.fromkeys(lst))
+
+
+def _common_prefix(a: list[str], b: list[str]) -> list[str]:
+    """2つのリストの共通プレフィックスを返す"""
+    return [x for x, y in zip(a, b) if x == y]

--- a/rds_analyzer/analyzers/recommendation_engine.py
+++ b/rds_analyzer/analyzers/recommendation_engine.py
@@ -51,6 +51,7 @@ class RecommendationType(str, Enum):
     OPTIMIZE_BACKUP = "optimize_backup"            # バックアップ設定最適化
     UPGRADE_GRAVITON = "upgrade_graviton"          # Graviton インスタンスへ移行
     REDUCE_CONNECTIONS = "reduce_connections"      # コネクション削減（PgBouncer等）
+    ADD_COVERING_INDEX = "add_covering_index"      # カバリングインデックス追加
 
 
 @dataclass

--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -27,16 +27,22 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from .schemas import (
     AnalysisResponse,
     CostSummaryResponse,
+    CoveringIndexRecommendationResponse,
+    ExistingIndexRequest,
     HealthCheckResponse,
+    IndexAnalysisApiRequest,
+    IndexAnalysisResponse,
     InstanceSummaryItem,
     MetricsInputRequest,
     PerformanceSummaryResponse,
+    QueryPatternRequest,
     RDSInstanceRequest,
     RDSSummaryResponse,
     RecommendationItem,
     RecommendationResponse,
 )
 from ..analyzers.cost_analyzer import CostAnalyzer
+from ..analyzers.index_analyzer import CoveringIndexAnalyzer
 from ..analyzers.performance_analyzer import PerformanceAnalyzer
 from ..analyzers.recommendation_engine import RecommendationEngine
 from ..analyzers.ml_anomaly_detector import MLAnomalyDetector, CostForecast
@@ -45,6 +51,11 @@ from ..models.metrics import (
     MetricsHistory,
     MetricsStatistics,
     PerformanceAnalysisResult,
+)
+from ..models.index import (
+    ExistingIndex,
+    IndexAnalysisRequest,
+    QueryPattern,
 )
 from ..models.rds import EngineType, RDSInstance, StorageType
 from ..notifications.slack_notifier import SlackNotifier
@@ -599,6 +610,78 @@ async def generate_report(
         "generated_at": datetime.utcnow().isoformat(),
         "markdown": markdown,
     }
+
+
+@router.post(
+    "/rds/{instance_id}/index-analysis",
+    response_model=IndexAnalysisResponse,
+    tags=["analysis"],
+    summary="カバリングインデックス分析",
+)
+async def analyze_covering_indexes(
+    instance_id: str,
+    body: IndexAnalysisApiRequest,
+) -> IndexAnalysisResponse:
+    """
+    クエリパターンと既存インデックスを分析してカバリングインデックスを推奨する
+
+    **入力:**
+    - `queries`: 分析対象クエリパターン（WHERE/ORDER BY/SELECT カラム、実行統計）
+    - `existing_indexes`: 既存インデックス一覧（省略可）
+    - `engine`: DBエンジン（省略時はインスタンスのエンジンを使用）
+
+    **出力:**
+    - 既存インデックスでカバーされていないクエリへのカバリングインデックス推奨
+    - MySQL/MariaDB 用と PostgreSQL 用の両方の CREATE INDEX 文を生成
+    - `rows_examined / rows_returned` 比率に基づいた優先度付け
+
+    **カバリングインデックスの効果:**
+    - テーブルへのランダムアクセス（Key Lookup / Heap Fetch）を排除
+    - 大幅なレイテンシ改善（比率 1000:1 の場合、最大 99% 改善）
+    """
+    instance = get_instance_or_404(instance_id)
+    engine_str = body.engine or instance.engine.value
+
+    request = IndexAnalysisRequest(
+        instance_id=instance_id,
+        engine=engine_str,
+        queries=[
+            QueryPattern(**q.model_dump()) for q in body.queries
+        ],
+        existing_indexes=[
+            ExistingIndex(**i.model_dump()) for i in body.existing_indexes
+        ],
+    )
+
+    analyzer = CoveringIndexAnalyzer()
+    result = analyzer.analyze(request)
+
+    return IndexAnalysisResponse(
+        instance_id=result.instance_id,
+        analyzed_at=result.analyzed_at,
+        engine=result.engine,
+        total_queries_analyzed=result.total_queries_analyzed,
+        queries_already_covered=result.queries_already_covered,
+        queries_needing_index=result.queries_needing_index,
+        estimated_total_improvement_pct=result.estimated_total_improvement_pct,
+        recommendations=[
+            CoveringIndexRecommendationResponse(
+                recommendation_id=r.recommendation_id,
+                table_name=r.table_name,
+                priority=r.priority,
+                reason=r.reason,
+                key_columns=r.key_columns,
+                include_columns=r.include_columns,
+                estimated_scan_ratio=r.estimated_scan_ratio,
+                estimated_latency_improvement_pct=r.estimated_latency_improvement_pct,
+                estimated_daily_rows_saved=r.estimated_daily_rows_saved,
+                affected_query_count=len(r.affected_query_ids),
+                create_statement_mysql=r.create_statement_mysql,
+                create_statement_postgresql=r.create_statement_postgresql,
+            )
+            for r in result.recommendations
+        ],
+    )
 
 
 @router.post(

--- a/rds_analyzer/api/schemas.py
+++ b/rds_analyzer/api/schemas.py
@@ -174,3 +174,87 @@ class HealthCheckResponse(BaseModel):
     status: str = "ok"
     version: str
     timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+
+# ============================================================
+# カバリングインデックス分析
+# ============================================================
+
+class QueryPatternRequest(BaseModel):
+    """クエリパターン入力 (カバリングインデックス分析用)"""
+    query_id: str = Field(default="", description="クエリ識別子（任意）")
+    table_name: str = Field(description="対象テーブル名")
+    schema_name: str = Field(default="public", description="スキーマ名 (PostgreSQL)")
+
+    filter_columns: list[str] = Field(
+        default_factory=list,
+        description="WHERE/JOIN 条件カラム (インデックスキー候補)",
+    )
+    sort_columns: list[str] = Field(
+        default_factory=list, description="ORDER BY カラム"
+    )
+    group_columns: list[str] = Field(
+        default_factory=list, description="GROUP BY カラム"
+    )
+    select_columns: list[str] = Field(
+        default_factory=list,
+        description="SELECT カラム (空 = SELECT *、カバリング判定不能)",
+    )
+
+    execution_count_per_day: float = Field(default=0, ge=0, description="1日あたり実行回数")
+    avg_rows_examined: float = Field(default=0, ge=0, description="平均スキャン行数")
+    avg_rows_returned: float = Field(default=1, ge=1, description="平均返却行数")
+    avg_latency_ms: float = Field(default=0, ge=0, description="平均実行時間 (ms)")
+    query_text: Optional[str] = Field(default=None, description="クエリ文字列（参考）")
+
+
+class ExistingIndexRequest(BaseModel):
+    """既存インデックス入力"""
+    index_name: str
+    table_name: str
+    key_columns: list[str] = Field(description="キーカラム (順序通り)")
+    include_columns: list[str] = Field(
+        default_factory=list, description="INCLUDE カラム (PostgreSQL 11+)"
+    )
+    is_unique: bool = False
+    index_type: str = Field(default="BTREE")
+
+
+class IndexAnalysisApiRequest(BaseModel):
+    """POST /rds/{id}/index-analysis リクエスト"""
+    engine: Optional[str] = Field(
+        default=None,
+        description="エンジン種別 (mysql/mariadb/postgresql)。省略時はインスタンスのエンジンを使用",
+    )
+    queries: list[QueryPatternRequest] = Field(description="分析対象クエリパターン一覧")
+    existing_indexes: list[ExistingIndexRequest] = Field(
+        default_factory=list, description="既存インデックス一覧"
+    )
+
+
+class CoveringIndexRecommendationResponse(BaseModel):
+    """カバリングインデックス推奨アイテム"""
+    recommendation_id: str
+    table_name: str
+    priority: str = Field(description="critical / high / medium / low")
+    reason: str
+    key_columns: list[str]
+    include_columns: list[str] = Field(description="PostgreSQL INCLUDE カラム")
+    estimated_scan_ratio: float = Field(description="rows_examined / rows_returned 比率")
+    estimated_latency_improvement_pct: float
+    estimated_daily_rows_saved: float
+    affected_query_count: int
+    create_statement_mysql: str
+    create_statement_postgresql: str
+
+
+class IndexAnalysisResponse(BaseModel):
+    """POST /rds/{id}/index-analysis レスポンス"""
+    instance_id: str
+    analyzed_at: datetime
+    engine: str
+    total_queries_analyzed: int
+    queries_already_covered: int
+    queries_needing_index: int
+    estimated_total_improvement_pct: float
+    recommendations: list[CoveringIndexRecommendationResponse]

--- a/rds_analyzer/models/index.py
+++ b/rds_analyzer/models/index.py
@@ -1,0 +1,112 @@
+"""
+インデックス分析データモデル
+
+カバリングインデックス分析のための入力・出力モデル定義
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class QueryPattern(BaseModel):
+    """クエリパターン（カバリングインデックス分析の入力単位）"""
+
+    query_id: str = Field(default="", description="クエリ識別子")
+    table_name: str = Field(description="対象テーブル名")
+    schema_name: str = Field(default="public", description="スキーマ名 (PostgreSQL)")
+
+    # カラム使用状況
+    filter_columns: list[str] = Field(
+        default_factory=list,
+        description="WHERE/JOIN 条件で使用するカラム (インデックスキー候補)",
+    )
+    sort_columns: list[str] = Field(
+        default_factory=list,
+        description="ORDER BY で使用するカラム",
+    )
+    group_columns: list[str] = Field(
+        default_factory=list,
+        description="GROUP BY で使用するカラム",
+    )
+    select_columns: list[str] = Field(
+        default_factory=list,
+        description="SELECT で取得するカラム (空 = SELECT *、判定不能)",
+    )
+
+    # クエリ統計
+    execution_count_per_day: float = Field(default=0, ge=0, description="1日あたりの実行回数")
+    avg_rows_examined: float = Field(default=0, ge=0, description="平均スキャン行数")
+    avg_rows_returned: float = Field(default=1, ge=1, description="平均返却行数")
+    avg_latency_ms: float = Field(default=0, ge=0, description="平均実行時間 (ms)")
+
+    query_text: Optional[str] = Field(default=None, description="クエリ文字列 (参考情報)")
+
+
+class ExistingIndex(BaseModel):
+    """既存インデックス情報"""
+
+    index_name: str
+    table_name: str
+    key_columns: list[str] = Field(description="インデックスキーカラム (順序通り)")
+    include_columns: list[str] = Field(
+        default_factory=list,
+        description="INCLUDE カラム (PostgreSQL 11+ / SQL Server)",
+    )
+    is_unique: bool = False
+    index_type: str = Field(default="BTREE", description="BTREE / HASH / GIN / GiST")
+
+
+class IndexAnalysisRequest(BaseModel):
+    """カバリングインデックス分析リクエスト"""
+
+    instance_id: str
+    engine: str = Field(description="mysql / mariadb / postgresql")
+    queries: list[QueryPattern]
+    existing_indexes: list[ExistingIndex] = Field(default_factory=list)
+
+
+class CoveringIndexRecommendation(BaseModel):
+    """カバリングインデックス推奨"""
+
+    recommendation_id: str
+    table_name: str
+    key_columns: list[str] = Field(description="インデックスキーカラム")
+    include_columns: list[str] = Field(
+        default_factory=list,
+        description="PostgreSQL INCLUDE カラム (非キー列)",
+    )
+
+    priority: str = Field(description="critical / high / medium / low")
+    reason: str
+    affected_query_ids: list[str] = Field(default_factory=list)
+
+    estimated_scan_ratio: float = Field(
+        description="改善前の rows_examined / rows_returned 比率"
+    )
+    estimated_latency_improvement_pct: float
+    estimated_daily_rows_saved: float
+
+    create_statement_mysql: str = Field(description="MySQL/MariaDB 用 CREATE INDEX 文")
+    create_statement_postgresql: str = Field(description="PostgreSQL 用 CREATE INDEX 文")
+
+
+class IndexAnalysisResult(BaseModel):
+    """カバリングインデックス分析結果"""
+
+    instance_id: str
+    analyzed_at: datetime
+    engine: str
+
+    total_queries_analyzed: int
+    queries_already_covered: int
+    queries_needing_index: int
+
+    recommendations: list[CoveringIndexRecommendation]
+
+    estimated_total_improvement_pct: float = Field(
+        description="推奨インデックス適用後の推定改善効果 (%)"
+    )

--- a/tests/test_index_analyzer.py
+++ b/tests/test_index_analyzer.py
@@ -1,0 +1,405 @@
+"""
+CoveringIndexAnalyzer テスト
+
+カバリングインデックス分析エンジンのユニットテスト
+"""
+
+import pytest
+
+from rds_analyzer.analyzers.index_analyzer import CoveringIndexAnalyzer
+from rds_analyzer.models.index import (
+    ExistingIndex,
+    IndexAnalysisRequest,
+    QueryPattern,
+)
+
+
+# ──────────────────────────────────────────────
+# テストヘルパー
+# ──────────────────────────────────────────────
+
+def make_query(
+    table: str = "orders",
+    filter_cols: list[str] | None = None,
+    sort_cols: list[str] | None = None,
+    select_cols: list[str] | None = None,
+    group_cols: list[str] | None = None,
+    rows_examined: float = 10000,
+    rows_returned: float = 10,
+    exec_per_day: float = 100,
+    latency_ms: float = 50,
+    query_id: str = "q1",
+) -> QueryPattern:
+    return QueryPattern(
+        query_id=query_id,
+        table_name=table,
+        filter_columns=filter_cols or [],
+        sort_columns=sort_cols or [],
+        select_columns=select_cols or [],
+        group_columns=group_cols or [],
+        avg_rows_examined=rows_examined,
+        avg_rows_returned=rows_returned,
+        execution_count_per_day=exec_per_day,
+        avg_latency_ms=latency_ms,
+    )
+
+
+def make_index(
+    table: str,
+    name: str,
+    key_cols: list[str],
+    include_cols: list[str] | None = None,
+) -> ExistingIndex:
+    return ExistingIndex(
+        index_name=name,
+        table_name=table,
+        key_columns=key_cols,
+        include_columns=include_cols or [],
+    )
+
+
+def make_request(
+    queries: list[QueryPattern],
+    indexes: list[ExistingIndex] | None = None,
+    engine: str = "mysql",
+) -> IndexAnalysisRequest:
+    return IndexAnalysisRequest(
+        instance_id="db-test-01",
+        engine=engine,
+        queries=queries,
+        existing_indexes=indexes or [],
+    )
+
+
+# ──────────────────────────────────────────────
+# カバリング判定テスト
+# ──────────────────────────────────────────────
+
+class TestIsCovered:
+    def test_no_indexes_returns_not_covered(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(filter_cols=["status"], select_cols=["id", "amount"])
+        result = analyzer.analyze(make_request([query], indexes=[]))
+        assert result.queries_already_covered == 0
+
+    def test_exact_covering_index_detected(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["status"],
+            sort_cols=["created_at"],
+            select_cols=["id", "amount"],
+        )
+        idx = make_index("orders", "idx_covering", ["status", "created_at", "id", "amount"])
+        result = analyzer.analyze(make_request([query], indexes=[idx]))
+        assert result.queries_already_covered == 1
+        assert result.queries_needing_index == 0
+        assert result.recommendations == []
+
+    def test_postgresql_include_columns_count_as_covered(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["user_id"],
+            select_cols=["email", "name"],
+            engine_str="postgresql",
+        ) if False else make_query(
+            filter_cols=["user_id"],
+            select_cols=["email", "name"],
+        )
+        idx = make_index("orders", "idx_pg", ["user_id"], include_cols=["email", "name"])
+        result = analyzer.analyze(make_request([query], indexes=[idx], engine="postgresql"))
+        assert result.queries_already_covered == 1
+
+    def test_index_missing_select_column_not_covered(self):
+        analyzer = CoveringIndexAnalyzer()
+        # インデックスに 'amount' がない
+        query = make_query(
+            filter_cols=["status"],
+            select_cols=["id", "amount"],
+        )
+        idx = make_index("orders", "idx_partial", ["status", "id"])
+        result = analyzer.analyze(make_request([query], indexes=[idx]))
+        assert result.queries_already_covered == 0
+        assert len(result.recommendations) == 1
+
+    def test_index_for_different_table_not_counted(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(table="orders", filter_cols=["status"], select_cols=["id"])
+        idx = make_index("users", "idx_users", ["status", "id"])
+        result = analyzer.analyze(make_request([query], indexes=[idx]))
+        assert result.queries_already_covered == 0
+
+    def test_filter_not_prefix_of_key_not_covered(self):
+        # インデックスは (a, b, c) だが filter は (b,) — プレフィックス不一致
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(filter_cols=["b"], select_cols=["a", "c"])
+        idx = make_index("orders", "idx_abc", ["a", "b", "c"])
+        result = analyzer.analyze(make_request([query], indexes=[idx]))
+        assert result.queries_already_covered == 0
+
+
+# ──────────────────────────────────────────────
+# 推奨生成テスト (MySQL)
+# ──────────────────────────────────────────────
+
+class TestRecommendationMySQL:
+    def test_basic_covering_index_recommended(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["status"],
+            sort_cols=["created_at"],
+            select_cols=["id", "amount"],
+            rows_examined=10000,
+            rows_returned=10,
+        )
+        result = analyzer.analyze(make_request([query], engine="mysql"))
+        assert len(result.recommendations) == 1
+        rec = result.recommendations[0]
+        assert rec.table_name == "orders"
+        assert "status" in rec.key_columns
+        assert "created_at" in rec.key_columns
+
+    def test_mysql_create_statement_format(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["status"],
+            select_cols=["id", "amount"],
+            rows_examined=1000,
+            rows_returned=1,
+        )
+        result = analyzer.analyze(make_request([query], engine="mysql"))
+        stmt = result.recommendations[0].create_statement_mysql
+        assert stmt.startswith("CREATE INDEX")
+        assert "`orders`" in stmt
+        assert "`status`" in stmt
+        # MySQL: select_cols はキーに追加される
+        assert "`id`" in stmt or "`amount`" in stmt
+
+    def test_mysql_no_include_clause(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["category_id"],
+            select_cols=["name", "price"],
+            rows_examined=5000,
+            rows_returned=5,
+        )
+        result = analyzer.analyze(make_request([query], engine="mysql"))
+        stmt = result.recommendations[0].create_statement_mysql
+        assert "INCLUDE" not in stmt
+
+    def test_no_where_clause_skipped(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=[],  # WHERE 句なし
+            select_cols=["id", "name"],
+            rows_examined=50000,
+            rows_returned=50000,
+        )
+        result = analyzer.analyze(make_request([query]))
+        assert result.recommendations == []
+
+    def test_low_scan_ratio_skipped(self):
+        analyzer = CoveringIndexAnalyzer()
+        # ratio = 9 < 10 → スキップ
+        query = make_query(
+            filter_cols=["id"],
+            select_cols=["name"],
+            rows_examined=9,
+            rows_returned=1,
+        )
+        result = analyzer.analyze(make_request([query]))
+        assert result.recommendations == []
+
+
+# ──────────────────────────────────────────────
+# 推奨生成テスト (PostgreSQL)
+# ──────────────────────────────────────────────
+
+class TestRecommendationPostgreSQL:
+    def test_postgresql_include_clause_generated(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["user_id"],
+            sort_cols=["created_at"],
+            select_cols=["email", "name"],  # キーにない → INCLUDE 候補
+            rows_examined=10000,
+            rows_returned=1,
+        )
+        result = analyzer.analyze(make_request([query], engine="postgresql"))
+        rec = result.recommendations[0]
+        pg_stmt = rec.create_statement_postgresql
+        assert "INCLUDE" in pg_stmt
+        assert '"email"' in pg_stmt or '"name"' in pg_stmt
+
+    def test_postgresql_key_columns_not_duplicated_in_include(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["user_id"],
+            select_cols=["user_id", "email"],  # user_id は既にキー
+            rows_examined=5000,
+            rows_returned=1,
+        )
+        result = analyzer.analyze(make_request([query], engine="postgresql"))
+        rec = result.recommendations[0]
+        # user_id はキーに既にあるので INCLUDE に含まれない
+        assert "user_id" not in rec.include_columns
+
+    def test_mariadb_no_include_clause(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["status"],
+            select_cols=["id", "amount"],
+            rows_examined=5000,
+            rows_returned=5,
+        )
+        result = analyzer.analyze(make_request([query], engine="mariadb"))
+        stmt = result.recommendations[0].create_statement_postgresql
+        # mariadb は INCLUDE 構文なし
+        assert "INCLUDE" not in stmt
+
+
+# ──────────────────────────────────────────────
+# 優先度テスト
+# ──────────────────────────────────────────────
+
+class TestPriority:
+    def test_critical_priority_high_ratio_high_frequency(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["status"],
+            rows_examined=100000,
+            rows_returned=10,   # ratio = 10000
+            exec_per_day=500,
+        )
+        result = analyzer.analyze(make_request([query]))
+        assert result.recommendations[0].priority == "critical"
+
+    def test_high_priority_high_ratio(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["category"],
+            rows_examined=1000,
+            rows_returned=5,    # ratio = 200
+            exec_per_day=10,
+        )
+        result = analyzer.analyze(make_request([query]))
+        assert result.recommendations[0].priority == "high"
+
+    def test_medium_priority_moderate_ratio(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["region"],
+            rows_examined=500,
+            rows_returned=20,   # ratio = 25
+            exec_per_day=50,
+        )
+        result = analyzer.analyze(make_request([query]))
+        assert result.recommendations[0].priority == "medium"
+
+
+# ──────────────────────────────────────────────
+# 推定値テスト
+# ──────────────────────────────────────────────
+
+class TestEstimates:
+    def test_improvement_pct_capped_at_95(self):
+        analyzer = CoveringIndexAnalyzer()
+        # ratio = 1000000 → 理論値 99.9999% → キャップ 95%
+        query = make_query(
+            filter_cols=["id"],
+            rows_examined=1_000_000,
+            rows_returned=1,
+        )
+        result = analyzer.analyze(make_request([query]))
+        assert result.recommendations[0].estimated_latency_improvement_pct == 95.0
+
+    def test_scan_ratio_computed_correctly(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["status"],
+            rows_examined=3000,
+            rows_returned=30,   # ratio = 100
+        )
+        result = analyzer.analyze(make_request([query]))
+        assert result.recommendations[0].estimated_scan_ratio == 100.0
+
+    def test_daily_rows_saved_computed(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["status"],
+            rows_examined=1000,
+            rows_returned=10,
+            exec_per_day=200,
+        )
+        result = analyzer.analyze(make_request([query]))
+        assert result.recommendations[0].estimated_daily_rows_saved == 200_000.0
+
+
+# ──────────────────────────────────────────────
+# マージテスト
+# ──────────────────────────────────────────────
+
+class TestMerge:
+    def test_queries_on_same_table_with_common_prefix_are_merged(self):
+        analyzer = CoveringIndexAnalyzer()
+        q1 = make_query(
+            table="orders", query_id="q1",
+            filter_cols=["status", "user_id"],
+            select_cols=["id"],
+            rows_examined=10000, rows_returned=10,
+        )
+        q2 = make_query(
+            table="orders", query_id="q2",
+            filter_cols=["status", "user_id"],
+            select_cols=["amount"],
+            rows_examined=5000, rows_returned=5,
+        )
+        result = analyzer.analyze(make_request([q1, q2]))
+        # 同じテーブル・同じキープレフィックス → マージされて1件
+        assert len(result.recommendations) == 1
+        rec = result.recommendations[0]
+        assert rec.table_name == "orders"
+
+    def test_queries_on_different_tables_not_merged(self):
+        analyzer = CoveringIndexAnalyzer()
+        q1 = make_query(table="orders", query_id="q1", filter_cols=["status"],
+                        rows_examined=10000, rows_returned=10)
+        q2 = make_query(table="products", query_id="q2", filter_cols=["category"],
+                        rows_examined=5000, rows_returned=5)
+        result = analyzer.analyze(make_request([q1, q2]))
+        assert len(result.recommendations) == 2
+        tables = {r.table_name for r in result.recommendations}
+        assert "orders" in tables
+        assert "products" in tables
+
+
+# ──────────────────────────────────────────────
+# 集計テスト
+# ──────────────────────────────────────────────
+
+class TestAggregation:
+    def test_total_improvement_pct_is_average(self):
+        analyzer = CoveringIndexAnalyzer()
+        # q1: ratio=100 → improvement ~99%, capped 95%
+        # q2: ratio=20  → improvement ~95%
+        q1 = make_query(table="t1", query_id="q1", filter_cols=["a"],
+                        rows_examined=10000, rows_returned=100)
+        q2 = make_query(table="t2", query_id="q2", filter_cols=["b"],
+                        rows_examined=1000, rows_returned=50)
+        result = analyzer.analyze(make_request([q1, q2]))
+        assert result.estimated_total_improvement_pct > 0
+
+    def test_empty_queries_returns_zero_improvement(self):
+        analyzer = CoveringIndexAnalyzer()
+        result = analyzer.analyze(make_request([]))
+        assert result.total_queries_analyzed == 0
+        assert result.recommendations == []
+        assert result.estimated_total_improvement_pct == 0.0
+
+    def test_all_covered_returns_zero_recommendations(self):
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(filter_cols=["x"], select_cols=["y"])
+        idx = make_index("orders", "idx_xy", ["x", "y"])
+        result = analyzer.analyze(make_request([query], indexes=[idx]))
+        assert result.queries_already_covered == 1
+        assert result.recommendations == []
+        assert result.estimated_total_improvement_pct == 0.0


### PR DESCRIPTION
クエリパターン（WHERE/ORDER BY/SELECT カラム）と既存インデックスを照合し
カバリングインデックスが有効な箇所を検出・推奨する機能を追加。

追加ファイル:
- rds_analyzer/models/index.py: QueryPattern / ExistingIndex / IndexAnalysisRequest / CoveringIndexRecommendation など Pydantic v2 モデル
- rds_analyzer/analyzers/index_analyzer.py: CoveringIndexAnalyzer — rows_examined/rows_returned 比率を基にスキャン検出、MySQL/PostgreSQL 両方の CREATE INDEX 文を生成
- tests/test_index_analyzer.py: 25 テスト (カバリング判定・推奨生成・優先度・推定値・マージ・集計)

変更ファイル:
- recommendation_engine.py: RecommendationType.ADD_COVERING_INDEX を追加
- api/schemas.py: IndexAnalysisApiRequest / IndexAnalysisResponse など API スキーマを追加
- api/routes.py: POST /rds/{id}/index-analysis エンドポイントを追加

主な設計ポイント:
- MySQL/MariaDB: 全カラムをキーに含める (key + select)
- PostgreSQL 11+: key カラム + INCLUDE (select カラム) で構文が異なる
- 同一テーブルへの複数推奨は共通プレフィックスがある場合にマージ
- スキャン比率 < 10 の場合は推奨しない (改善余地が小さい)

https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG