### PR TITLE
security: replace MD5 with SHA-256 for cache keys; fix metrics module…

### DIFF
--- a/project/app/api/metrics.py
+++ b/project/app/api/metrics.py
@@ -41,6 +41,12 @@ except ImportError:  # pragma: no cover
 
 # ---- メトリクス定義 ----
 
+# モジュールレベルで初期化（prometheus 非インストール時も属性として存在させる）
+PREDICT_REQUESTS = None
+PREDICT_LATENCY = None
+MODEL_INFO = None
+MODEL_LOADED = None
+
 if _PROMETHEUS_AVAILABLE:
     # 予測リクエスト総数（status=success/error でラベル分け）
     PREDICT_REQUESTS = Counter(

--- a/project/app/cache.py
+++ b/project/app/cache.py
@@ -79,7 +79,7 @@ def _make_cache_key(race_data: dict[str, Any], race_id: str | None = None) -> st
     """
     raw = race_id or json.dumps(race_data, sort_keys=True, ensure_ascii=False)
 
-    key_hash = hashlib.md5(raw.encode()).hexdigest()
+    key_hash = hashlib.sha256(raw.encode()).hexdigest()
     return f"{_KEY_PREFIX}{key_hash}"
 
 


### PR DESCRIPTION
… stubs

- cache.py: _make_cache_key() now uses hashlib.sha256 instead of md5 (MD5 is cryptographically broken and flagged by security scanners even for non-cryptographic use; SHA-256 has negligible additional overhead)
- metrics.py: define PREDICT_REQUESTS, PREDICT_LATENCY, MODEL_INFO, MODEL_LOADED as None at module level so tests can monkeypatch these attributes regardless of whether prometheus-client is installed

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy