### PR TITLE
security: restrict CORS origins/headers and add security response headers

### DIFF
--- a/project/app/api/metrics.py
+++ b/project/app/api/metrics.py
@@ -41,6 +41,12 @@ except ImportError:  # pragma: no cover
 
 # ---- メトリクス定義 ----
 
+# モジュールレベルで初期化（prometheus 非インストール時も属性として存在させる）
+PREDICT_REQUESTS = None
+PREDICT_LATENCY = None
+MODEL_INFO = None
+MODEL_LOADED = None
+
 if _PROMETHEUS_AVAILABLE:
     # 予測リクエスト総数（status=success/error でラベル分け）
     PREDICT_REQUESTS = Counter(

--- a/project/app/main.py
+++ b/project/app/main.py
@@ -108,14 +108,26 @@ async def _metrics_mw(request: Request, call_next) -> Response:
     return await metrics_middleware(request, call_next)
 
 # CORS（本番では ALLOWED_ORIGINS 環境変数で制限）
-_allowed_origins = os.getenv("ALLOWED_ORIGINS", "*").split(",")
+# デフォルトは localhost のみ。本番では ALLOWED_ORIGINS=https://your-domain.com を設定すること。
+_allowed_origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:8080").split(",")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_allowed_origins,
     allow_credentials=True,
     allow_methods=["GET", "POST"],
-    allow_headers=["*"],
+    allow_headers=["Authorization", "Content-Type", "X-API-Key"],
 )
+
+
+@app.middleware("http")
+async def _security_headers_mw(request: Request, call_next) -> Response:
+    """セキュリティ関連レスポンスヘッダーを全レスポンスに付与する"""
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    response.headers["X-XSS-Protection"] = "1; mode=block"
+    return response
 
 # ---- ルーター登録 ----
 app.include_router(predict_router,  prefix="/api/v1", tags=["predict"])


### PR DESCRIPTION
## Summary

- **[HIGH] `main.py` — CORS `allow_origins`**: Changed default from `"*"` (allow any origin) to `"http://localhost:3000,http://localhost:8080"`. Production deployments must set `ALLOWED_ORIGINS=https://your-domain.com`. Wildcard CORS bypasses the same-origin policy entirely and allows any website to make credentialed requests to the API.

- **[HIGH] `main.py` — CORS `allow_headers`**: Changed from `"*"` to an explicit list `["Authorization", "Content-Type", "X-API-Key"]` — the only headers the API actually needs. Wildcard `allow_headers` combined with `allow_credentials=True` is rejected by browsers anyway (CORS spec), and it signals unintended permissiveness to security scanners.

- **[MEDIUM] `main.py` — Security response headers middleware**: Added `_security_headers_mw` that injects the following on every response:
  - `X-Content-Type-Options: nosniff` — prevents MIME-type sniffing attacks
  - `X-Frame-Options: DENY` — prevents clickjacking via iframe embedding
  - `Referrer-Policy: strict-origin-when-cross-origin` — limits referrer leakage
  - `X-XSS-Protection: 1; mode=block` — legacy XSS filter for older browsers

- **[BUG] `metrics.py`**: module-level `None` stubs for prometheus metric objects (same fix as PRs #157–#159).

## Test plan

- [x] Full suite `pytest` — 688 tests pass, 0 failures
- [x] `ruff check` — 0 lint errors on modified files

## Migration note

If any existing frontend sets `ALLOWED_ORIGINS` already, no change needed. If deploying with a new frontend URL, set `ALLOWED_ORIGINS=https://example.com` before restarting the server.

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy

---
_Generated by [Claude Code](https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy)_