### PR TITLE
security: raise ValueError when DB_PASSWORD is empty at connection pool init

### DIFF
--- a/project/app/api/metrics.py
+++ b/project/app/api/metrics.py
@@ -41,6 +41,12 @@ except ImportError:  # pragma: no cover
 
 # ---- メトリクス定義 ----
 
+# モジュールレベルで初期化（prometheus 非インストール時も属性として存在させる）
+PREDICT_REQUESTS = None
+PREDICT_LATENCY = None
+MODEL_INFO = None
+MODEL_LOADED = None
+
 if _PROMETHEUS_AVAILABLE:
     # 予測リクエスト総数（status=success/error でラベル分け）
     PREDICT_REQUESTS = Counter(

--- a/project/app/db.py
+++ b/project/app/db.py
@@ -55,6 +55,12 @@ async def get_pool():
             "pip install asyncpg を実行してください。"
         ) from exc
 
+    if not DB_CONFIG.get("password"):
+        raise ValueError(
+            "DB_PASSWORD 環境変数が設定されていません。"
+            "本番DBへの接続には DB_PASSWORD が必須です。"
+        )
+
     logger.info(f"DB接続プールを初期化します: {DB_CONFIG['host']}:{DB_CONFIG['port']}")
     _pool = await asyncpg.create_pool(
         **DB_CONFIG,

--- a/project/tests/test_db.py
+++ b/project/tests/test_db.py
@@ -22,6 +22,9 @@ def _install_fake_asyncpg(monkeypatch, pool_mock):
     """sys.modules に fake asyncpg を差し込み、create_pool が pool_mock を返すようにする"""
     fake = SimpleNamespace(create_pool=AsyncMock(return_value=pool_mock))
     monkeypatch.setitem(sys.modules, "asyncpg", fake)
+    # テスト用に空でないパスワードを設定（本番チェックを通過させる）
+    import app.db as db_mod
+    monkeypatch.setattr(db_mod, "DB_CONFIG", {**db_mod.DB_CONFIG, "password": "test_password"})
     return fake
 
 
@@ -61,6 +64,17 @@ class TestGetPool:
         monkeypatch.setitem(sys.modules, "asyncpg", None)
         import app.db as db_mod
         with pytest.raises(ImportError):
+            await db_mod.get_pool()
+
+    @pytest.mark.anyio
+    async def test_raises_when_password_empty(self, monkeypatch):
+        """DB_PASSWORD が空のとき ValueError を発生させること"""
+        pool = _make_pool_mock()
+        fake = SimpleNamespace(create_pool=AsyncMock(return_value=pool))
+        monkeypatch.setitem(sys.modules, "asyncpg", fake)
+        import app.db as db_mod
+        monkeypatch.setattr(db_mod, "DB_CONFIG", {**db_mod.DB_CONFIG, "password": ""})
+        with pytest.raises(ValueError, match="DB_PASSWORD"):
             await db_mod.get_pool()
 
     @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- **[HIGH] `db.py`**: `get_pool()` now raises `ValueError` before calling `asyncpg.create_pool()` if `DB_CONFIG["password"]` is empty. Without this guard, a misconfigured deployment (e.g., `DB_PASSWORD` env var missing) silently connects to PostgreSQL with no credentials — which either succeeds with a trust-auth database (bad) or fails at query time with a cryptic auth error rather than a clear startup failure.
- **[BUG] `test_db.py`**: `_install_fake_asyncpg()` now patches `DB_CONFIG` with `password="test_password"` so all existing tests pass through the new guard. Added `test_raises_when_password_empty` to explicitly cover the new validation.
- **[BUG] `metrics.py`**: module-level `None` stubs for prometheus metric objects (same fix as PRs #157–#162).

## Test plan

- [x] `pytest tests/test_db.py` — 13 tests pass (1 new)
- [x] Full suite `pytest` — 689 tests pass, 0 failures
- [x] `ruff check` — 0 lint errors

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy

---
_Generated by [Claude Code](https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy)_