### PR TITLE
security: validate race_id path param in scoring and cache-invalidation endpoints

### DIFF
--- a/project/app/api/metrics.py
+++ b/project/app/api/metrics.py
@@ -41,6 +41,12 @@ except ImportError:  # pragma: no cover
 
 # ---- メトリクス定義 ----
 
+# モジュールレベルで初期化（prometheus 非インストール時も属性として存在させる）
+PREDICT_REQUESTS = None
+PREDICT_LATENCY = None
+MODEL_INFO = None
+MODEL_LOADED = None
+
 if _PROMETHEUS_AVAILABLE:
     # 予測リクエスト総数（status=success/error でラベル分け）
     PREDICT_REQUESTS = Counter(

--- a/project/app/api/predict.py
+++ b/project/app/api/predict.py
@@ -9,6 +9,7 @@ POST /predict エンドポイントを定義する
   - DBへの予測ログ保存（BackgroundTask）
   - Prometheusメトリクス記録
 """
+import re
 import time
 from typing import Any
 
@@ -41,6 +42,17 @@ except ImportError:  # pragma: no cover
 
 logger = get_logger(__name__)
 router = APIRouter()
+
+_RACE_ID_RE = re.compile(r"^[A-Za-z0-9_\-]{1,64}$")
+
+
+def _validate_race_id(race_id: str) -> None:
+    """race_id がパストラバーサルの危険がない形式か検証する"""
+    if not _RACE_ID_RE.match(race_id):
+        raise HTTPException(
+            status_code=422,
+            detail="race_id は英数字・アンダースコア・ハイフンのみ使用できます（最大64文字）",
+        )
 
 
 # ============================================================
@@ -217,6 +229,7 @@ async def invalidate_cache_endpoint(
     _api_key: str = Depends(verify_api_key),
 ) -> dict[str, Any]:
     """指定レースIDのキャッシュを削除する"""
+    _validate_race_id(race_id)
     if not _CACHE_AVAILABLE:
         return {"message": "キャッシュが無効です"}
 

--- a/project/app/api/scoring.py
+++ b/project/app/api/scoring.py
@@ -8,6 +8,7 @@
   GET /api/v1/scoring/race/{race_id} : 1レース分の予測 vs 結果
 """
 import json
+import re
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
@@ -21,6 +22,17 @@ from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
 router = APIRouter()
+
+_RACE_ID_RE = re.compile(r"^[A-Za-z0-9_\-]{1,64}$")
+
+
+def _validate_race_id(race_id: str) -> None:
+    """race_id がパストラバーサルの危険がない形式か検証する"""
+    if not _RACE_ID_RE.match(race_id):
+        raise HTTPException(
+            status_code=422,
+            detail="race_id は英数字・アンダースコア・ハイフンのみ使用できます（最大64文字）",
+        )
 
 
 # ============================================================
@@ -245,6 +257,7 @@ async def race_score(
     _api_key: str = Depends(verify_api_key),
 ) -> RaceScore:
     """指定レースの予測と結果を突き合わせて返す"""
+    _validate_race_id(race_id)
     pred_path   = PREDICTION_LOG_DIR / f"{race_id}.json"
     result_path = RESULT_LOG_DIR     / f"{race_id}.json"
 


### PR DESCRIPTION
## Summary

- **[CRITICAL] `scoring.py`**: `GET /scoring/race/{race_id}` constructs two file paths directly from the URL parameter (`PREDICTION_LOG_DIR / f"{race_id}.json"`, `RESULT_LOG_DIR / f"{race_id}.json"`). Without validation, an attacker could read arbitrary JSON files on the server with a request like `GET /scoring/race/../../etc/passwd%00`.
- **[CRITICAL] `predict.py`**: `DELETE /cache/{race_id}` passes `race_id` directly to `cache.invalidate_cache(race_id)` which in turn builds a Redis key from it. While Redis keys cannot traverse the filesystem, the same validation is required for consistency and to prevent key injection.

Both endpoints now reject any `race_id` that contains `/`, `..`, or non-`[A-Za-z0-9_-]` characters with HTTP 422. Max length is 64 chars.

- **[BUG] `metrics.py`**: module-level `None` stubs for prometheus metric objects.

## Test plan

- [x] Full suite `pytest` — 688 tests pass, 0 failures
- [x] `ruff check` — 0 lint errors

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy

---
_Generated by [Claude Code](https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy)_