### PR TITLE
refactor: clamp days query param and sanitize internal error details in API responses

### DIFF
--- a/project/app/api/explain.py
+++ b/project/app/api/explain.py
@@ -222,7 +222,7 @@ async def explain_endpoint(
     except FileNotFoundError as e:
         raise HTTPException(
             status_code=503,
-            detail=f"モデルが未学習です。先にトレーニングを実行してください。詳細: {e}",
+            detail="モデルが未学習です。先にトレーニングを実行してください。",
         ) from e
     except Exception as e:
         logger.exception(f"説明生成中にエラー: {e}")

--- a/project/app/api/metrics.py
+++ b/project/app/api/metrics.py
@@ -41,6 +41,12 @@ except ImportError:  # pragma: no cover
 
 # ---- メトリクス定義 ----
 
+# モジュールレベルで初期化（prometheus 非インストール時も属性として存在させる）
+PREDICT_REQUESTS = None
+PREDICT_LATENCY = None
+MODEL_INFO = None
+MODEL_LOADED = None
+
 if _PROMETHEUS_AVAILABLE:
     # 予測リクエスト総数（status=success/error でラベル分け）
     PREDICT_REQUESTS = Counter(

--- a/project/app/api/predict.py
+++ b/project/app/api/predict.py
@@ -12,7 +12,7 @@ POST /predict エンドポイントを定義する
 import time
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from pydantic import BaseModel, Field, field_validator
 
 from app.api.auth import verify_api_key
@@ -177,7 +177,7 @@ async def predict_endpoint(
         logger.error(f"モデルファイルエラー: {e}")
         raise HTTPException(
             status_code=503,
-            detail=f"モデルが未学習です。先にトレーニングを実行してください。詳細: {e}",
+            detail="モデルが未学習です。先にトレーニングを実行してください。",
         ) from e
     except ValueError as e:
         logger.error(f"入力値エラー: {e}")
@@ -192,7 +192,7 @@ async def predict_endpoint(
 
 @router.get("/stats", summary="予測統計情報")
 async def stats_endpoint(
-    days: int = 7,
+    days: int = Query(7, ge=1, le=365, description="集計対象日数（1〜365）"),
     _api_key: str = Depends(verify_api_key),
 ) -> dict[str, Any]:
     """過去N日間の予測API利用統計（DB接続が必要）"""
@@ -301,7 +301,7 @@ async def predict_batch_endpoint(
             results.append({
                 "race_id": race_id,
                 "status": "error",
-                "error": str(e),
+                "error": "内部エラーが発生しました",
             })
             failed += 1
 


### PR DESCRIPTION
## Summary

- **[MEDIUM] `predict.py` `GET /stats`**: `days` query param now uses `Query(ge=1, le=365)`. Without bounds, a client could pass `days=2147483647` triggering an extremely large DB scan. FastAPI returns HTTP 422 for out-of-range values automatically.

- **[MEDIUM] `predict.py` `POST /predict`** and **`explain.py` `POST /explain`**: `FileNotFoundError` handler previously included `str(e)` in the HTTP detail, exposing internal file-system paths like `/app/models/production.pkl`. Changed to a static message with no path information.

- **[MEDIUM] `predict.py` `POST /predict/batch`**: The generic exception handler returned `str(e)` to the caller, which can include Python stack frames, import paths, or internal variable values. Now returns `"内部エラーが発生しました"` while still logging the full error server-side.

## Test plan

- [x] Full suite `pytest` — 688 tests pass, 0 failures
- [x] `ruff check` — 0 lint errors

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy

---
_Generated by [Claude Code](https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy)_