### PR TITLE
fix: add module-level None stubs for prometheus metric objects

### DIFF
--- a/project/app/api/metrics.py
+++ b/project/app/api/metrics.py
@@ -41,6 +41,12 @@ except ImportError:  # pragma: no cover
 
 # ---- メトリクス定義 ----
 
+# モジュールレベルで初期化（prometheus 非インストール時も属性として存在させる）
+PREDICT_REQUESTS = None
+PREDICT_LATENCY = None
+MODEL_INFO = None
+MODEL_LOADED = None
+
 if _PROMETHEUS_AVAILABLE:
     # 予測リクエスト総数（status=success/error でラベル分け）
     PREDICT_REQUESTS = Counter(


### PR DESCRIPTION
## Summary

`PREDICT_REQUESTS`, `PREDICT_LATENCY`, `MODEL_INFO`, `MODEL_LOADED` were only defined inside `if _PROMETHEUS_AVAILABLE:`. When `prometheus-client` is not installed (common in CI / local dev), these names did not exist as module attributes. `monkeypatch.setattr(met, "PREDICT_REQUESTS", bad_counter)` then raises `AttributeError`, breaking `test_record_predict_request_counter_exception_swallowed`.

Fix: define all four as `None` at module level before the `if` block. When prometheus is available, the `if` block overwrites them with real `Counter`/`Histogram`/`Info`/`Gauge` instances. The `record_predict_request()` function already guards with `if not _PROMETHEUS_AVAILABLE: return` so the `None` values are never called.

## Test plan

- [x] `pytest tests/test_auth_metrics.py` — 33 tests pass (previously 1 failure)
- [x] Full suite `pytest` — 688 tests pass, 0 failures

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy

---
_Generated by [Claude Code](https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy)_