### PR TITLE
feat: 称号・実績システム追加

### DIFF
--- a/yankee.py
+++ b/yankee.py
@@ -56,6 +56,51 @@ def get_rank(respect: int) -> tuple[str, str]:
     return "チンピラ", "…"
 
 
+# ─── 称号・実績システム ───────────────────────────────────
+# (条件関数, 称号名, 説明)
+ACHIEVEMENTS: list[tuple] = [
+    (lambda y: y.win_streak >= 1,                    "初勝利",         "初めての勝利"),
+    (lambda y: y.win_streak >= 5,                    "五連覇",         "5連勝達成"),
+    (lambda y: y.win_streak >= 10,                   "無敗伝説",       "10連勝達成"),
+    (lambda y: y.respect >= 100,                     "番長の証",       "仁義100pt到達"),
+    (lambda y: y.respect >= 200,                     "伝説の男",       "仁義200pt到達"),
+    (lambda y: y.gold >= 500,                        "金持ちヤンキー", "所持金500円超え"),
+    (lambda y: len(y.items) >= 3,                    "武装完了",       "アイテム3個以上装備"),
+    (lambda y: len(y.territories_owned) >= 3,        "縄張り拡大",     "3つ以上の縄張りを支配"),
+    (lambda y: y.base_atk >= 20,                     "修行の成果",     "修行で攻撃力+20"),
+    (lambda y: y.max_hp >= 150,                      "鉄の肉体",       "最大HP150超え"),
+    (lambda y: len(y.rivals) >= 3,                   "多くの宿敵",     "ライバル3人以上"),
+    (lambda y: y.respect >= 60 and y.gold >= 200,    "幹部の風格",     "幹部ランクで金持ち"),
+]
+
+
+def check_achievements(yankee: "Yankee") -> list[str]:
+    """新たに解除された称号リストを返す"""
+    newly_unlocked: list[str] = []
+    for condition, title, desc in ACHIEVEMENTS:
+        if title not in yankee.unlocked_achievements:
+            try:
+                if condition(yankee):
+                    yankee.unlocked_achievements.add(title)
+                    newly_unlocked.append(f"  🏆 称号解除「{title}」— {desc}")
+            except Exception:
+                pass
+    return newly_unlocked
+
+
+def show_achievements(yankee: "Yankee") -> None:
+    """称号一覧を表示する"""
+    print(f"\n  ── {yankee.name} の称号 ──────────────────")
+    unlocked = 0
+    for _, title, desc in ACHIEVEMENTS:
+        if title in yankee.unlocked_achievements:
+            print(f"  [✓] {title:12s}  {desc}")
+            unlocked += 1
+        else:
+            print(f"  [ ] ????????    （未解除）")
+    print(f"  {unlocked}/{len(ACHIEVEMENTS)} 解除済み")
+
+
 # ─── Yankee クラス ────────────────────────────────────────
 class Yankee:
     """不良ヤンキーキャラクタークラス"""
@@ -130,6 +175,7 @@ class Yankee:
         self.rivals: list["Yankee"] = []
         self.items: list[Item] = []           # 所持アイテム
         self.territories_owned: list[str] = [territory]  # 支配縄張り
+        self.unlocked_achievements: set[str] = set()
 
     def __repr__(self) -> str:
         rank, icon = get_rank(self.respect)


### PR DESCRIPTION
## 概要
12種の達成条件による称号解除システムを追加。

## 変更内容
- `ACHIEVEMENTS`: 12条件（初勝利/五連覇/無敗伝説/番長の証/伝説の男/金持ちヤンキー等）
- `check_achievements(yankee)`: 新規解除された称号を返す
- `show_achievements(yankee)`: 解除済み/未解除一覧を表示（未解除はネタバレ防止で`????????`）
- `Yankee.unlocked_achievements: set[str]` フィールド追加

---
_Generated by [Claude Code](https://claude.ai/code/session_014EYoVnQ7banVJATGteHSYU)_