### PR TITLE
refactor: add sanitize_for_log() to prevent log injection from user-controlled values

### DIFF
--- a/project/app/api/feedback.py
+++ b/project/app/api/feedback.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, Field
 from app.api.auth import verify_api_key
 from app.api.scoring import _rank_proba
 from app.config import AB_LOG_DIR, PREDICTION_LOG_DIR, RESULT_LOG_DIR
-from app.utils.logger import get_logger
+from app.utils.logger import get_logger, sanitize_for_log
 
 logger = get_logger(__name__)
 router = APIRouter()
@@ -175,7 +175,7 @@ async def record_result(
         pass
 
     logger.info(
-        f"結果記録: race_id={race_id} winner={body.true_winner} "
+        f"結果記録: race_id={sanitize_for_log(race_id)} winner={body.true_winner} "
         f"correct={comparison['is_correct']}"
     )
 

--- a/project/app/api/metrics.py
+++ b/project/app/api/metrics.py
@@ -41,6 +41,12 @@ except ImportError:  # pragma: no cover
 
 # ---- メトリクス定義 ----
 
+# モジュールレベルで初期化（prometheus 非インストール時も属性として存在させる）
+PREDICT_REQUESTS = None
+PREDICT_LATENCY = None
+MODEL_INFO = None
+MODEL_LOADED = None
+
 if _PROMETHEUS_AVAILABLE:
     # 予測リクエスト総数（status=success/error でラベル分け）
     PREDICT_REQUESTS = Counter(

--- a/project/app/api/predict.py
+++ b/project/app/api/predict.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field, field_validator
 from app.api.auth import verify_api_key
 from app.model.features import N_BOATS
 from app.model.predict import predict_race
-from app.utils.logger import get_logger
+from app.utils.logger import get_logger, sanitize_for_log
 
 # オプション依存モジュール
 try:
@@ -136,7 +136,7 @@ async def predict_endpoint(
     race_id = request.race_id
 
     try:
-        logger.info(f"予測リクエスト受信: race_id={race_id}")
+        logger.info(f"予測リクエスト受信: race_id={sanitize_for_log(race_id)}")
 
         # ---- キャッシュ確認 ----
         if _CACHE_AVAILABLE:
@@ -297,7 +297,7 @@ async def predict_batch_endpoint(
             })
             failed += 1
         except Exception as e:
-            logger.error(f"バッチ予測エラー race_id={race_id}: {e}")
+            logger.error(f"バッチ予測エラー race_id={sanitize_for_log(race_id)}: {e}")
             results.append({
                 "race_id": race_id,
                 "status": "error",

--- a/project/app/utils/logger.py
+++ b/project/app/utils/logger.py
@@ -8,6 +8,18 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 
+def sanitize_for_log(value: object, max_len: int = 200) -> str:
+    """ユーザー入力をログ出力前にサニタイズする（ログインジェクション対策）。
+    改行・キャリッジリターン・タブ・ヌルバイトを可視エスケープに置換し、
+    長さを max_len 文字に切り詰める。
+    """
+    text = str(value)
+    text = text.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t").replace("\x00", "\\x00")
+    if len(text) > max_len:
+        text = text[:max_len] + "…"
+    return text
+
+
 def get_logger(name: str, log_level: str = "INFO") -> logging.Logger:
     """
     名前付きロガーを取得する


### PR DESCRIPTION
## Summary

**[MEDIUM] Log injection (CWE-117)**: When user-controlled values (e.g. `race_id` from URL path params) are embedded in log messages without sanitization, an attacker can craft a `race_id` containing `\n[CRITICAL] admin - Injected log entry` to forge fake log records. This can mislead operators, corrupt SIEM ingestion, or bypass alert rules that scan logs.

- **`logger.py`**: New `sanitize_for_log(value, max_len=200)` helper that:
  - Replaces `\n`, `\r`, `\t`, `\x00` with their visible escape representations
  - Truncates values longer than `max_len` characters with `…`
- **`predict.py`**: `race_id` sanitized in `POST /predict` info log and `POST /predict/batch` error log
- **`feedback.py`**: `race_id` sanitized in `POST /result/{race_id}` success info log

## Test plan

- [x] Full suite `pytest` — 688 tests pass, 0 failures
- [x] `ruff check` — 0 lint errors

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy

---
_Generated by [Claude Code](https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy)_