### PR TITLE
feat: 状態異常システム追加 (激怒/集中/疲労/奮起)

### DIFF
--- a/yankee.py
+++ b/yankee.py
@@ -7,6 +7,7 @@ import json
 import random
 import time
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 
 
@@ -54,6 +55,60 @@ def get_rank(respect: int) -> tuple[str, str]:
         if respect >= threshold:
             return title, icon
     return "チンピラ", "…"
+
+
+# ─── 状態異常 ─────────────────────────────────────────────
+class StatusEffect(Enum):
+    RAGE     = "激怒"    # ATK +50%
+    FOCUS    = "集中"    # 必殺技確率 2倍
+    FATIGUE  = "疲労"    # ATK -30%
+    INSPIRED = "奮起"    # 回復量 +20%
+
+_STATUS_DURATION: dict[StatusEffect, int] = {
+    StatusEffect.RAGE:     2,
+    StatusEffect.FOCUS:    2,
+    StatusEffect.FATIGUE:  3,
+    StatusEffect.INSPIRED: 999,
+}
+
+
+@dataclass
+class ActiveStatus:
+    effect: StatusEffect
+    remaining_turns: int
+
+    def tick(self) -> bool:
+        self.remaining_turns -= 1
+        return self.remaining_turns > 0
+
+    def __str__(self) -> str:
+        return f"{self.effect.value}({self.remaining_turns}T)"
+
+
+def apply_status(yankee: "Yankee", effect: StatusEffect) -> None:
+    """状態異常を付与する（同種は上書き）"""
+    yankee.active_statuses = [s for s in yankee.active_statuses if s.effect != effect]
+    dur = _STATUS_DURATION[effect]
+    yankee.active_statuses.append(ActiveStatus(effect, dur))
+    print(f"  {yankee.name} に【{effect.value}】付与！ ({dur}T)")
+
+
+def tick_statuses(yankee: "Yankee") -> None:
+    """ターン終了時に全状態異常を1T進める"""
+    expired = [s for s in yankee.active_statuses if not s.tick()]
+    for s in expired:
+        yankee.active_statuses.remove(s)
+        print(f"  {yankee.name} の【{s.effect.value}】が切れた")
+
+
+def get_atk_multiplier(yankee: "Yankee") -> float:
+    mult = 1.0
+    for s in yankee.active_statuses:
+        if s.effect == StatusEffect.RAGE:
+            mult *= 1.5
+        elif s.effect == StatusEffect.FATIGUE:
+            mult *= 0.7
+    return mult
 
 
 # ─── Yankee クラス ────────────────────────────────────────
@@ -130,6 +185,7 @@ class Yankee:
         self.rivals: list["Yankee"] = []
         self.items: list[Item] = []           # 所持アイテム
         self.territories_owned: list[str] = [territory]  # 支配縄張り
+        self.active_statuses: list[ActiveStatus] = []
 
     def __repr__(self) -> str:
         rank, icon = get_rank(self.respect)


### PR DESCRIPTION
## 概要
バトル中の状態変化を管理する状態異常システムを追加。

## 変更内容
- `StatusEffect` Enum: 激怒(ATK×1.5)/集中(必殺技確率2倍)/疲労(ATK×0.7)/奮起
- `ActiveStatus` dataclass: 効果と残りターン管理
- `apply_status()`: 同種は上書きで付与
- `tick_statuses()`: ターン終了時に残ターン-1、切れたら自動除去
- `get_atk_multiplier()`: 状態異常考慮の攻撃倍率を返す
- `Yankee.active_statuses` フィールド追加

---
_Generated by [Claude Code](https://claude.ai/code/session_014EYoVnQ7banVJATGteHSYU)_