### PR TITLE
feat: CLIコマンドライン引数対応 (--name / --rpg / --demo / --no-sleep)

### DIFF
--- a/yankee.py
+++ b/yankee.py
@@ -797,5 +797,47 @@ def main() -> None:
         play_interactive()
 
 
+# ─── CLIエントリポイント ──────────────────────────────────
+def parse_args() -> "argparse.Namespace":
+    import argparse
+    p = argparse.ArgumentParser(
+        description="不良ヤンキーシミュレーター",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+使用例:
+  python yankee.py
+  python yankee.py --rpg --name タロウ --territory 北区
+  python yankee.py --demo
+  python yankee.py --status --name テスト
+""",
+    )
+    p.add_argument("--name",      default="タケシ",   help="ヤンキーの名前")
+    p.add_argument("--territory", default="東側",     help="縄張りの名前")
+    p.add_argument("--rpg",       action="store_true", help="インタラクティブRPGを直接起動")
+    p.add_argument("--demo",      action="store_true", help="デモ（ノンインタラクティブ）を実行")
+    p.add_argument("--status",    action="store_true", help="キャラクターのステータスのみ表示")
+    p.add_argument("--no-sleep",  action="store_true", help="time.sleep をスキップして高速実行")
+    return p.parse_args()
+
+
 if __name__ == "__main__":
-    main()
+    import sys
+    _args = parse_args()
+
+    if _args.no_sleep:
+        time.sleep = lambda _: None  # type: ignore[assignment]
+
+    if _args.rpg:
+        play_interactive()
+    elif _args.status:
+        y = Yankee(_args.name, _args.territory)
+        y.show_face()
+    elif _args.demo:
+        a = Yankee(_args.name, _args.territory)
+        b = Yankee("対戦相手", "向こう側")
+        a.show_face()
+        a.fight(b)
+        import json as _json
+        print(_json.dumps(a.status(), ensure_ascii=False, indent=2))
+    else:
+        main()


### PR DESCRIPTION
## 概要

`yankee.py` にCLIコマンドライン引数サポートを追加。`argparse` を使って各種モードをフラグで切り替えられるようにした。

## 追加した機能

### `parse_args()` 関数
- `--name` : ヤンキーの名前を指定（デフォルト: タケシ）
- `--territory` : 縄張りを指定（デフォルト: 東側）
- `--rpg` : インタラクティブRPGモードを直接起動
- `--demo` : デモ（ノンインタラクティブ）を実行し、ステータスをJSONで出力
- `--status` : キャラクターのステータスと顔グラのみ表示
- `--no-sleep` : `time.sleep` をスキップして高速実行（テスト・CI向け）

## 使用例

```bash
python yankee.py
python yankee.py --rpg --name タロウ --territory 北区
python yankee.py --demo --name テスト次郎
python yankee.py --status --name 最強番長
python yankee.py --demo --no-sleep
```

## テスト

既存43テスト全て通過。`parse_args()` は `__main__` ブロック内でのみ呼ばれるため既存テストへの影響なし。

---
_Generated by [Claude Code](https://claude.ai/code/session_014EYoVnQ7banVJATGteHSYU)_