### PR TITLE
refactor: validate race_id format in POST /predict request body

### DIFF
--- a/project/app/api/metrics.py
+++ b/project/app/api/metrics.py
@@ -41,6 +41,12 @@ except ImportError:  # pragma: no cover
 
 # ---- メトリクス定義 ----
 
+# モジュールレベルで初期化（prometheus 非インストール時も属性として存在させる）
+PREDICT_REQUESTS = None
+PREDICT_LATENCY = None
+MODEL_INFO = None
+MODEL_LOADED = None
+
 if _PROMETHEUS_AVAILABLE:
     # 予測リクエスト総数（status=success/error でラベル分け）
     PREDICT_REQUESTS = Counter(

--- a/project/app/api/predict.py
+++ b/project/app/api/predict.py
@@ -9,6 +9,7 @@ POST /predict エンドポイントを定義する
   - DBへの予測ログ保存（BackgroundTask）
   - Prometheusメトリクス記録
 """
+import re
 import time
 from typing import Any
 
@@ -68,10 +69,20 @@ class WeatherInfo(BaseModel):
     water_temp: float = Field(20.0, description="水温 (℃)")
 
 
+_RACE_ID_RE = re.compile(r"^[A-Za-z0-9_\-]{1,64}$")
+
+
 class RaceRequest(BaseModel):
     """POST /predict のリクエストボディ"""
-    race_id: str | None = Field(None, description="レースID（任意）")
+    race_id: str | None = Field(None, description="レースID（任意、英数字・_・- のみ最大64文字）")
     race: dict[str, Any] = Field(..., description="レース情報")
+
+    @field_validator("race_id")
+    @classmethod
+    def validate_race_id_format(cls, v: str | None) -> str | None:
+        if v is not None and not _RACE_ID_RE.match(v):
+            raise ValueError("race_id は英数字・アンダースコア・ハイフンのみ使用できます（最大64文字）")
+        return v
 
     @field_validator("race")
     @classmethod


### PR DESCRIPTION
## Summary

- Add `_RACE_ID_RE` regex pattern and `validate_race_id_format` Pydantic `field_validator` to `RaceRequest` model
- Prevents malformed or injection-risk `race_id` values from reaching downstream cache, DB log, and metrics code
- Add module-level `None` stubs for all 4 Prometheus metric objects (`PREDICT_REQUESTS`, `PREDICT_LATENCY`, `MODEL_INFO`, `MODEL_LOADED`) so tests can monkeypatch them without `prometheus-client` installed

## Security

Closes an input-validation gap where arbitrary strings could be passed as `race_id` and flow into Redis keys, DB writes, and log statements. Now validated at the Pydantic layer with the same `^[A-Za-z0-9_\-]{1,64}$` pattern used by other endpoints.

## Test plan

- [ ] `python3 -m pytest tests/ -p no:cov -q` — all 688+ tests pass
- [ ] `ruff check app/api/predict.py app/api/metrics.py` from `project/` — no errors
- [ ] POST `/predict` with `race_id: "../../etc/passwd"` returns HTTP 422
- [ ] POST `/predict` with valid `race_id: "race-2024-01"` proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy

---
_Generated by [Claude Code](https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy)_