### PR TITLE
fix: admin API timing attack, info disclosure, and path traversal

### DIFF
--- a/project/app/api/admin.py
+++ b/project/app/api/admin.py
@@ -12,6 +12,8 @@
 """
 import json
 import os
+import re
+import secrets
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -31,10 +33,21 @@ router = APIRouter()
 # 管理者権限確認（通常の API Key 認証に加え ADMIN_KEY 環境変数で絞り込み可）
 _ADMIN_KEY = os.getenv("ADMIN_API_KEY", "")
 
+_SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9_\-]{1,64}$")
+
+
+def _validate_safe_name(name: str) -> None:
+    """シャドウログ名を検証してパストラバーサルを防ぐ"""
+    if not _SAFE_NAME_RE.match(name):
+        raise HTTPException(
+            status_code=422,
+            detail="name は英数字・アンダースコア・ハイフンのみ使用できます（最大64文字）",
+        )
+
 
 def verify_admin_key(api_key: str = Depends(verify_api_key)) -> str:
     """管理者 API Key を検証する（ADMIN_API_KEY 未設定時は通常認証と同等）"""
-    if _ADMIN_KEY and api_key != _ADMIN_KEY:
+    if _ADMIN_KEY and not secrets.compare_digest(api_key, _ADMIN_KEY):
         raise HTTPException(status_code=403, detail="管理者権限が必要です")
     return api_key
 
@@ -255,7 +268,7 @@ async def promote_model(
         }
     except Exception as e:
         logger.error(f"モデル昇格エラー: {e}")
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=500, detail="モデル昇格中にエラーが発生しました") from e
 
 
 @router.get(
@@ -278,7 +291,8 @@ async def get_drift_report(
         with open(reports[-1], encoding="utf-8") as f:
             return json.load(f)
     except (json.JSONDecodeError, OSError) as e:
-        raise HTTPException(status_code=500, detail=f"レポート読み込みエラー: {e}") from e
+        logger.error(f"ドリフトレポート読み込みエラー: {e}")
+        raise HTTPException(status_code=500, detail="ドリフトレポートの読み込みに失敗しました") from e
 
 
 @router.get(
@@ -301,6 +315,7 @@ async def get_shadow_stats(
     _api_key: str = Depends(verify_admin_key),
 ) -> dict[str, Any]:
     """シャドウモードの累積統計を返す"""
+    _validate_safe_name(name)
     return _read_shadow_stats(name)
 
 
@@ -313,6 +328,7 @@ async def clear_shadow_log(
     _api_key: str = Depends(verify_admin_key),
 ) -> dict[str, str]:
     """指定シャドウログファイルを削除する"""
+    _validate_safe_name(name)
     log_path = SHADOW_LOG_DIR / f"{name}.jsonl"
     if not log_path.exists():
         raise HTTPException(status_code=404, detail=f"ログ {name} が見つかりません")

--- a/project/app/api/metrics.py
+++ b/project/app/api/metrics.py
@@ -41,6 +41,12 @@ except ImportError:  # pragma: no cover
 
 # ---- メトリクス定義 ----
 
+# モジュールレベルで初期化（prometheus 非インストール時も属性として存在させる）
+PREDICT_REQUESTS = None
+PREDICT_LATENCY = None
+MODEL_INFO = None
+MODEL_LOADED = None
+
 if _PROMETHEUS_AVAILABLE:
     # 予測リクエスト総数（status=success/error でラベル分け）
     PREDICT_REQUESTS = Counter(


### PR DESCRIPTION
## Summary

Three security fixes in `app/api/admin.py`:

### 1. Timing attack in `verify_admin_key` (CWE-208)
```python
# before (vulnerable — short-circuit on first mismatch)
if _ADMIN_KEY and api_key != _ADMIN_KEY:

# after (constant-time comparison)
if _ADMIN_KEY and not secrets.compare_digest(api_key, _ADMIN_KEY):
```

### 2. Path traversal in shadow log endpoints (CWE-22)
`GET /admin/shadow?name=../../etc/passwd` previously resolved to an arbitrary path. Added `_SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9_\-]{1,64}$")` guard applied in both `get_shadow_stats()` and `clear_shadow_log()`.

### 3. Information disclosure in error responses (CWE-209)
- `promote_model`: `detail=str(e)` → static message (real error logged instead)
- `get_drift_report`: `detail=f"...{e}"` → static message (real error logged instead)

### Bonus: metrics.py testability
- Add module-level `None` stubs for all 4 Prometheus metric objects so tests can monkeypatch them without `prometheus-client` installed

## Test plan

- [ ] `python3 -m pytest tests/test_admin.py tests/test_auth_metrics.py -p no:cov -q` — all 61 tests pass
- [ ] `ruff check app/api/admin.py` — no errors
- [ ] `GET /admin/shadow?name=../../etc/passwd` → HTTP 422
- [ ] `DELETE /admin/shadow/../../etc/passwd` → HTTP 422
- [ ] Correct admin key → HTTP 200; wrong key → HTTP 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy

---
_Generated by [Claude Code](https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy)_