### PR TITLE
fix: path traversal and log injection in feedback API

### DIFF
--- a/project/app/api/feedback.py
+++ b/project/app/api/feedback.py
@@ -9,6 +9,7 @@ A/B テスト・シャドウモードの精度追跡に使用する
   GET  /api/v1/result/summary    : 直近の的中率サマリー
 """
 import json
+import re
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -19,10 +20,20 @@ from pydantic import BaseModel, Field
 from app.api.auth import verify_api_key
 from app.api.scoring import _rank_proba
 from app.config import AB_LOG_DIR, PREDICTION_LOG_DIR, RESULT_LOG_DIR
-from app.utils.logger import get_logger
+from app.utils.logger import get_logger, sanitize_for_log
 
 logger = get_logger(__name__)
 router = APIRouter()
+
+_RACE_ID_RE = re.compile(r"^[A-Za-z0-9_\-]{1,64}$")
+
+
+def _validate_race_id(race_id: str) -> None:
+    if not _RACE_ID_RE.match(race_id):
+        raise HTTPException(
+            status_code=422,
+            detail="race_id は英数字・アンダースコア・ハイフンのみ使用できます（最大64文字）",
+        )
 
 RESULT_LOG_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -141,6 +152,7 @@ async def record_result(
     _api_key: str = Depends(verify_api_key),
 ) -> RaceResultResponse:
     """レース結果を記録する"""
+    _validate_race_id(race_id)
     path = _result_path(race_id)
     if path.exists():
         raise HTTPException(
@@ -175,7 +187,7 @@ async def record_result(
         pass
 
     logger.info(
-        f"結果記録: race_id={race_id} winner={body.true_winner} "
+        f"結果記録: race_id={sanitize_for_log(race_id)} winner={body.true_winner} "
         f"correct={comparison['is_correct']}"
     )
 
@@ -251,6 +263,7 @@ async def get_result(
     _api_key: str = Depends(verify_api_key),
 ) -> RaceResultResponse:
     """記録済みのレース結果を返す"""
+    _validate_race_id(race_id)
     path = _result_path(race_id)
     if not path.exists():
         raise HTTPException(

--- a/project/app/api/metrics.py
+++ b/project/app/api/metrics.py
@@ -41,6 +41,12 @@ except ImportError:  # pragma: no cover
 
 # ---- メトリクス定義 ----
 
+# モジュールレベルで初期化（prometheus 非インストール時も属性として存在させる）
+PREDICT_REQUESTS = None
+PREDICT_LATENCY = None
+MODEL_INFO = None
+MODEL_LOADED = None
+
 if _PROMETHEUS_AVAILABLE:
     # 予測リクエスト総数（status=success/error でラベル分け）
     PREDICT_REQUESTS = Counter(

--- a/project/app/utils/logger.py
+++ b/project/app/utils/logger.py
@@ -52,3 +52,22 @@ def get_logger(name: str, log_level: str = "INFO") -> logging.Logger:
     logger.addHandler(file_handler)
 
     return logger
+
+
+def sanitize_for_log(value: object, max_len: int = 200) -> str:
+    """
+    ログに書き出す前にユーザー入力をサニタイズする（CWE-117 ログインジェクション対策）
+
+    - 改行・タブ・NUL を可視エスケープに変換
+    - 200文字を超える場合は切り詰める
+    """
+    text = str(value)
+    text = (
+        text.replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+            .replace("\x00", "\\x00")
+    )
+    if len(text) > max_len:
+        text = text[:max_len] + "…"
+    return text


### PR DESCRIPTION
## Summary

### feedback.py — Path traversal (CWE-22)

`POST /result/{race_id}` and `GET /result/{race_id}` passed the URL `race_id` directly to `RESULT_LOG_DIR / f"{race_id}.json"` without validation. A crafted path like `../../etc/passwd` could escape the result log directory.

Added `_RACE_ID_RE = re.compile(r"^[A-Za-z0-9_\-]{1,64}$")` and `_validate_race_id()` guard, called at the start of both `record_result()` and `get_result()`.

### feedback.py — Log injection (CWE-117)

```python
# before — raw user input written to log
logger.info(f"結果記録: race_id={race_id} ...")

# after — sanitized
logger.info(f"結果記録: race_id={sanitize_for_log(race_id)} ...")
```

### utils/logger.py — New `sanitize_for_log()` utility

Strips `\n`, `\r`, `\t`, `\x00` from user-supplied values and truncates to 200 chars before they reach the log stream. Prevents log forgery by injecting fake log entries.

## Test plan

- [ ] `python3 -m pytest tests/test_feedback.py tests/test_auth_metrics.py -p no:cov -q` — 57 tests pass
- [ ] `ruff check app/api/feedback.py app/utils/logger.py` — no errors
- [ ] `POST /result/../../etc/passwd` → HTTP 422
- [ ] `GET /result/../../etc/passwd` → HTTP 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy

---
_Generated by [Claude Code](https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy)_