### PR TITLE
fix: restrict CORS wildcard configuration and add security response headers

### DIFF
--- a/project/app/api/metrics.py
+++ b/project/app/api/metrics.py
@@ -41,6 +41,12 @@ except ImportError:  # pragma: no cover
 
 # ---- メトリクス定義 ----
 
+# モジュールレベルで初期化（prometheus 非インストール時も属性として存在させる）
+PREDICT_REQUESTS = None
+PREDICT_LATENCY = None
+MODEL_INFO = None
+MODEL_LOADED = None
+
 if _PROMETHEUS_AVAILABLE:
     # 予測リクエスト総数（status=success/error でラベル分け）
     PREDICT_REQUESTS = Counter(

--- a/project/app/main.py
+++ b/project/app/main.py
@@ -3,6 +3,7 @@ FastAPI アプリケーションエントリーポイント
 競艇予想AI APIサーバー
 """
 import os
+from collections.abc import Callable
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request, Response
@@ -107,14 +108,27 @@ app = FastAPI(
 async def _metrics_mw(request: Request, call_next) -> Response:
     return await metrics_middleware(request, call_next)
 
+# セキュリティレスポンスヘッダーミドルウェア
+@app.middleware("http")
+async def _security_headers_mw(request: Request, call_next: Callable) -> Response:
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    response.headers["X-XSS-Protection"] = "1; mode=block"
+    return response
+
 # CORS（本番では ALLOWED_ORIGINS 環境変数で制限）
-_allowed_origins = os.getenv("ALLOWED_ORIGINS", "*").split(",")
+_allowed_origins = os.getenv(
+    "ALLOWED_ORIGINS",
+    "http://localhost:3000,http://localhost:8080",
+).split(",")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_allowed_origins,
     allow_credentials=True,
     allow_methods=["GET", "POST"],
-    allow_headers=["*"],
+    allow_headers=["Authorization", "Content-Type", "X-API-Key"],
 )
 
 # ---- ルーター登録 ----


### PR DESCRIPTION
## Summary

### CORS misconfiguration (CWE-942)

Two wildcard settings allowed any origin to make credentialed cross-origin requests:

```python
# before
_allowed_origins = os.getenv("ALLOWED_ORIGINS", "*").split(",")
allow_headers=["*"]

# after
_allowed_origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:8080").split(",")
allow_headers=["Authorization", "Content-Type", "X-API-Key"]
```

Production deployments must set `ALLOWED_ORIGINS` to their actual frontend domain. The safe default now fails closed rather than open.

### Security response headers

Added `_security_headers_mw` middleware to every response:

| Header | Value |
|--------|-------|
| `X-Content-Type-Options` | `nosniff` — prevents MIME-type sniffing |
| `X-Frame-Options` | `DENY` — blocks clickjacking via iframe |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `X-XSS-Protection` | `1; mode=block` |

## Test plan

- [ ] `python3 -m pytest tests/test_main.py tests/test_auth_metrics.py -p no:cov -q` — 39 tests pass
- [ ] `ruff check app/main.py` — no errors
- [ ] Cross-origin request from an unallowed origin → blocked by browser
- [ ] Response headers include `X-Content-Type-Options: nosniff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy

---
_Generated by [Claude Code](https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy)_