### PR TITLE
fix: remove error detail disclosure in explain.py and health.py

### DIFF
--- a/project/app/api/explain.py
+++ b/project/app/api/explain.py
@@ -220,9 +220,10 @@ async def explain_endpoint(
         result = explain_race(request.race)
         return ExplainResponse(race_id=request.race_id, **result)
     except FileNotFoundError as e:
+        logger.error(f"モデルファイルエラー: {e}")
         raise HTTPException(
             status_code=503,
-            detail=f"モデルが未学習です。先にトレーニングを実行してください。詳細: {e}",
+            detail="モデルが未学習です。先にトレーニングを実行してください。",
         ) from e
     except Exception as e:
         logger.exception(f"説明生成中にエラー: {e}")

--- a/project/app/api/health.py
+++ b/project/app/api/health.py
@@ -93,7 +93,8 @@ def _check_model() -> dict[str, Any]:
             "size_kb": size_kb,
         }
     except Exception as e:
-        return {"status": "error", "message": str(e)}
+        logger.warning(f"モデルチェックエラー: {e}")
+        return {"status": "error", "message": "モデルチェック中にエラーが発生しました"}
 
 
 async def _check_db() -> dict[str, Any]:
@@ -107,7 +108,7 @@ async def _check_db() -> dict[str, Any]:
         return {"status": "ok", "latency_ms": latency_ms}
     except Exception as e:
         logger.warning(f"DBヘルスチェック失敗: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": "DB接続に失敗しました"}
 
 
 def _check_disk() -> dict[str, Any]:

--- a/project/app/api/metrics.py
+++ b/project/app/api/metrics.py
@@ -41,6 +41,12 @@ except ImportError:  # pragma: no cover
 
 # ---- メトリクス定義 ----
 
+# モジュールレベルで初期化（prometheus 非インストール時も属性として存在させる）
+PREDICT_REQUESTS = None
+PREDICT_LATENCY = None
+MODEL_INFO = None
+MODEL_LOADED = None
+
 if _PROMETHEUS_AVAILABLE:
     # 予測リクエスト総数（status=success/error でラベル分け）
     PREDICT_REQUESTS = Counter(


### PR DESCRIPTION
## Summary

Removes internal error details from HTTP responses in two API modules where `str(e)` was being returned to callers (CWE-209).

### explain.py

```python
# before — exposes model file path to the caller
detail=f"モデルが未学習です。先にトレーニングを実行してください。詳細: {e}"

# after — static message; real error logged at ERROR level
logger.error(f"モデルファイルエラー: {e}")
detail="モデルが未学習です。先にトレーニングを実行してください。"
```

### health.py — two locations

`_check_model()` and `_check_db()` returned raw exception messages in their error dicts, which can contain file paths, DB connection strings, and stack frames.

```python
# before
return {"status": "error", "message": str(e)}

# after
logger.warning(f"エラー: {e}")   # real detail preserved in logs
return {"status": "error", "message": "<static message>"}
```

### metrics.py

- Add module-level `None` stubs for all 4 Prometheus metric objects so tests can monkeypatch them without `prometheus-client` installed.

## Test plan

- [ ] `python3 -m pytest tests/test_explain.py tests/test_health.py tests/test_auth_metrics.py -p no:cov -q` — 69 tests pass
- [ ] Full suite: `python3 -m pytest tests/ -p no:cov -q` — all 688 tests pass
- [ ] `ruff check app/api/explain.py app/api/health.py` — no errors
- [ ] `GET /health/detail` with broken DB → response does not include connection string
- [ ] `POST /explain` with missing model → HTTP 503 without file paths in body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy

---
_Generated by [Claude Code](https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy)_