### PR TITLE
feat: リザーブドインスタンス推奨を RecommendationEngine に追加

### DIFF
--- a/rds_analyzer/analyzers/recommendation_engine.py
+++ b/rds_analyzer/analyzers/recommendation_engine.py
@@ -52,6 +52,7 @@ class RecommendationType(str, Enum):
     UPGRADE_GRAVITON = "upgrade_graviton"          # Graviton インスタンスへ移行
     REDUCE_CONNECTIONS = "reduce_connections"      # コネクション削減（PgBouncer等）
     ADD_COVERING_INDEX = "add_covering_index"      # カバリングインデックス追加
+    COST_OPTIMIZATION = "cost_optimization"        # コスト最適化（RI 購入など）
 
 
 @dataclass
@@ -217,6 +218,11 @@ class RecommendationEngine:
         if not instance.multi_az:
             rec = self._recommend_multi_az(instance, cost_breakdown)
             recommendations.append(rec)
+
+        # 11. リザーブドインスタンス推奨
+        ri_rec = self._recommend_reserved_instance(instance, cost_breakdown)
+        if ri_rec:
+            recommendations.append(ri_rec)
 
         # 優先度順（CRITICAL > HIGH > MEDIUM > LOW）でソート
         priority_order = {
@@ -629,6 +635,52 @@ class RecommendationEngine:
                 "フェイルオーバーテストを実施（任意）",
             ],
             reference_url="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html",
+        )
+
+    def _recommend_reserved_instance(
+        self,
+        instance: RDSInstance,
+        breakdown: CostBreakdown,
+    ) -> Optional[Recommendation]:
+        """リザーブドインスタンス購入によるコスト削減提案"""
+        monthly_cost = breakdown.compute_cost_usd
+
+        # 月額 $30 以下は節約効果が小さいため対象外
+        if monthly_cost <= 30:
+            return None
+
+        monthly_1yr_savings = monthly_cost * 0.35
+        monthly_3yr_savings = monthly_cost * 0.60
+        annual_1yr_savings = monthly_1yr_savings * 12
+
+        priority = (
+            RecommendationPriority.HIGH
+            if annual_1yr_savings >= 500
+            else RecommendationPriority.MEDIUM
+        )
+
+        return Recommendation(
+            recommendation_id=self._next_id("reserved"),
+            type=RecommendationType.COST_OPTIMIZATION,
+            priority=priority,
+            title=f"リザーブドインスタンス ({instance.instance_class}) で月額推定 ${monthly_1yr_savings:.2f} 削減",
+            description=(
+                f"1年リザーブド (35% 割引) で推定 ${monthly_1yr_savings:.2f}/月節約、"
+                f"3年リザーブド (60% 割引) で推定 ${monthly_3yr_savings:.2f}/月節約が見込めます。"
+                "これらは推定値です。実際の割引率はAWS公式料金表をご確認ください。"
+            ),
+            current_config=f"オンデマンド: {instance.instance_class} (推定 ${monthly_cost:.2f}/月)",
+            recommended_config=f"1年リザーブド: 推定 ${monthly_cost - monthly_1yr_savings:.2f}/月",
+            estimated_monthly_savings_usd=monthly_1yr_savings,
+            estimated_performance_improvement_pct=0.0,
+            implementation_complexity=1,
+            action_steps=[
+                "過去の使用状況を確認し、長期稼働が見込まれることを確認",
+                "AWS コンソール > Savings Plans または Reserved Instances で購入",
+                "1年または3年の契約期間と支払いオプション（全額前払い/一部前払い/前払いなし）を選択",
+                "購入後は自動的に割引が適用される（インスタンス変更不要）",
+            ],
+            reference_url="https://aws.amazon.com/rds/reserved-instances/",
         )
 
     # ----------------------------------------------------------

--- a/tests/test_recommendation_engine.py
+++ b/tests/test_recommendation_engine.py
@@ -224,3 +224,75 @@ class TestImpactSummary:
         recs = engine.generate_recommendations(inst, perf, bd)
         ids = [r.recommendation_id for r in recs]
         assert len(ids) == len(set(ids))
+
+
+class TestReservedInstanceRecommendation:
+    """リザーブドインスタンス推奨のテスト"""
+
+    def test_high_cost_instance_returns_recommendation(self, engine):
+        """月額コストが $30 超のインスタンスはリザーブドインスタンス推奨を返す"""
+        # db.m5.large は月額 $30 超のコストが想定される
+        inst = make_instance(instance_class="db.m5.large", multi_az=False, storage_type=StorageType.GP3)
+        perf = make_perf(inst, cpu_avg=40.0, cpu_max=60.0)
+        bd = make_cost_breakdown(inst)
+        recs = engine.generate_recommendations(inst, perf, bd)
+        types = [r.type for r in recs]
+        assert RecommendationType.COST_OPTIMIZATION in types
+
+    def test_low_cost_instance_returns_none(self, engine):
+        """月額コストが $30 以下のインスタンスはリザーブドインスタンス推奨を返さない"""
+        from rds_analyzer.models.costs import CostBreakdown
+
+        # compute_cost_usd を $30 以下に設定した低コストの CostBreakdown を直接作成
+        low_breakdown = CostBreakdown(compute_cost_usd=20.0, storage_cost_usd=5.0)
+        inst = make_instance(instance_class="db.t3.micro", multi_az=False, storage_type=StorageType.GP3)
+        result = engine._recommend_reserved_instance(inst, low_breakdown)
+        assert result is None
+
+    def test_recommendation_includes_1yr_and_3yr_savings(self, engine):
+        """推奨内容に1年・3年の節約額が含まれる"""
+        from rds_analyzer.models.costs import CostBreakdown
+
+        high_breakdown = CostBreakdown(compute_cost_usd=200.0, storage_cost_usd=10.0)
+        inst = make_instance(instance_class="db.m5.xlarge", multi_az=False, storage_type=StorageType.GP3)
+        rec = engine._recommend_reserved_instance(inst, high_breakdown)
+        assert rec is not None
+        # 1年節約額と3年節約額が説明文に含まれることを確認
+        assert "1年" in rec.description
+        assert "3年" in rec.description
+        # 推定値の注記が含まれることを確認
+        assert "推定" in rec.description
+
+    def test_estimated_monthly_savings_is_35_pct_of_instance_cost(self, engine):
+        """estimated_monthly_savings_usd がインスタンスコストの 35% であることを確認"""
+        from rds_analyzer.models.costs import CostBreakdown
+
+        compute_cost = 150.0
+        breakdown = CostBreakdown(compute_cost_usd=compute_cost, storage_cost_usd=10.0)
+        inst = make_instance(instance_class="db.r5.large", multi_az=False, storage_type=StorageType.GP3)
+        rec = engine._recommend_reserved_instance(inst, breakdown)
+        assert rec is not None
+        expected_savings = compute_cost * 0.35
+        assert abs(rec.estimated_monthly_savings_usd - expected_savings) < 0.001
+
+    def test_high_annual_savings_gets_high_priority(self, engine):
+        """年間節約額 $500 以上は HIGH 優先度になる"""
+        from rds_analyzer.models.costs import CostBreakdown
+
+        # monthly_1yr_savings = 200 * 0.35 = 70, annual = 840 >= 500 → HIGH
+        breakdown = CostBreakdown(compute_cost_usd=200.0, storage_cost_usd=10.0)
+        inst = make_instance(instance_class="db.m5.xlarge", multi_az=False, storage_type=StorageType.GP3)
+        rec = engine._recommend_reserved_instance(inst, breakdown)
+        assert rec is not None
+        assert rec.priority == RecommendationPriority.HIGH
+
+    def test_low_annual_savings_gets_medium_priority(self, engine):
+        """年間節約額 $500 未満は MEDIUM 優先度になる"""
+        from rds_analyzer.models.costs import CostBreakdown
+
+        # monthly_1yr_savings = 50 * 0.35 = 17.5, annual = 210 < 500 → MEDIUM
+        breakdown = CostBreakdown(compute_cost_usd=50.0, storage_cost_usd=5.0)
+        inst = make_instance(instance_class="db.t3.medium", multi_az=False, storage_type=StorageType.GP3)
+        rec = engine._recommend_reserved_instance(inst, breakdown)
+        assert rec is not None
+        assert rec.priority == RecommendationPriority.MEDIUM


### PR DESCRIPTION
## Summary

- `RecommendationEngine._recommend_reserved_instance()` を追加
  - 月額コスト > $30 の場合のみ推奨生成
  - 1年 35%割引 / 3年 60%割引の節約額を推定（推定値）
  - 年間節約 ≥$500 → HIGH、未満 → MEDIUM 優先度
- `generate_recommendations()` に組み込み
- `TestReservedInstanceRecommendation` (6テスト) 追加

## Test plan

- [ ] `python -m pytest tests/test_recommendation_engine.py -v` — 23テスト全件パス
- [ ] 高コストインスタンスで推奨が生成されることを確認
- [ ] $30以下のインスタンスでは推奨が生成されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_