### PR TITLE
feat: GET /health と GET /version エンドポイントを追加

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -131,7 +131,21 @@ def get_metrics_or_404(instance_id: str) -> MetricsHistory:
 @router.get("/health", response_model=HealthCheckResponse, tags=["system"])
 async def health_check() -> HealthCheckResponse:
     """サービスのヘルスチェック"""
-    return HealthCheckResponse(version=__version__)
+    return HealthCheckResponse(
+        version=__version__,
+        instance_count=len(_instance_store),
+        metrics_count=len(_metrics_store),
+    )
+
+
+@router.get("/version", response_model=dict, tags=["system"])
+async def get_version() -> dict:
+    """API バージョン情報を返す"""
+    return {
+        "version": __version__,
+        "api": "RDS Analyzer API",
+        "description": "AWS RDS コスト・パフォーマンス分析ツール",
+    }
 
 
 @router.post(

--- a/rds_analyzer/api/schemas.py
+++ b/rds_analyzer/api/schemas.py
@@ -177,6 +177,8 @@ class HealthCheckResponse(BaseModel):
     """ヘルスチェックレスポンス"""
     status: str = "ok"
     version: str
+    instance_count: int = 0
+    metrics_count: int = 0
     timestamp: datetime = Field(default_factory=datetime.utcnow)
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -71,6 +71,26 @@ class TestHealthCheck:
         assert data["status"] == "ok"
         assert "version" in data
 
+    def test_health_check_instance_count_after_register(
+        self, client, sample_instance_payload
+    ):
+        """インスタンス登録後に instance_count が増える"""
+        before = client.get("/api/v1/health").json()["instance_count"]
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        after = client.get("/api/v1/health").json()["instance_count"]
+        assert after == before + 1
+
+    def test_version_endpoint_returns_200(self, client):
+        response = client.get("/api/v1/version")
+        assert response.status_code == 200
+        data = response.json()
+        assert "version" in data
+
+    def test_version_endpoint_contains_api_key(self, client):
+        response = client.get("/api/v1/version")
+        data = response.json()
+        assert "api" in data
+
 
 class TestInstanceRegistration:
     def test_register_instance_success(self, client, sample_instance_payload):


### PR DESCRIPTION
## Summary

- `GET /health` を拡張: `instance_count`, `metrics_count` をインメモリストアから返す
- `GET /version` エンドポイントを新規追加: `version`, `api`, `description` を返す
- `TestHealthCheck` を1テスト→4テストに拡充

## Test plan

- [ ] `python -m pytest tests/test_api.py -v` — 37テスト全件パス
- [ ] インスタンス登録後に `instance_count` がインクリメントされることを確認
- [ ] `GET /version` が `version` と `api` キーを含むことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_