### PR TITLE
feat: バックアップ後に catalog.json を生成・更新する機能を追加

### DIFF
--- a/db_backup/backup.sh
+++ b/db_backup/backup.sh
@@ -62,6 +62,16 @@ main() {
 
     purge_old_files "${BACKUP_BASE_DIR}" "${FULL_RETENTION_DAYS}" "*"
 
+    # カタログ更新
+    local catalog_file="${BACKUP_BASE_DIR}/catalog.json"
+    local backed_files=()
+    while IFS= read -r f; do backed_files+=("$f"); done \
+        < <(find "${backup_dir}" -name "*.sql*" -newer "${catalog_file}" -type f 2>/dev/null \
+            || find "${backup_dir}" -name "*.sql*" -type f | sort -r | head -5)
+    if [[ ${#backed_files[@]} -gt 0 ]]; then
+        update_backup_catalog "${catalog_file}" "full" "${backed_files[@]}"
+    fi
+
     log_info "フルバックアップ完了: ${backup_dir}"
     log_info "=========================================="
 

--- a/db_backup/lib.sh
+++ b/db_backup/lib.sh
@@ -78,6 +78,59 @@ purge_old_files() {
     log_info "古いファイル削除: ${dir}/${pattern} (${days}日以前)"
 }
 
+# ─── バックアップカタログ更新 ─────────────────────────────────
+# バックアップカタログ（catalog.json）を更新
+# 引数: catalog_file backup_type backup_files...
+update_backup_catalog() {
+    local catalog_file="$1" backup_type="$2"
+    shift 2
+    local files=("$@")
+
+    local timestamp; timestamp=$(date '+%Y-%m-%dT%H:%M:%S%z')
+    local hostname; hostname=$(hostname)
+
+    # 各ファイルのサイズとチェックサム（md5 / md5sum）を収集
+    local file_entries="[]"
+    for f in "${files[@]}"; do
+        [[ ! -f "${f}" ]] && continue
+        local size_bytes; size_bytes=$(stat -c%s "${f}" 2>/dev/null || stat -f%z "${f}" 2>/dev/null || echo 0)
+        local checksum=""
+        if command -v md5sum &>/dev/null; then
+            checksum=$(md5sum "${f}" | awk '{print $1}')
+        elif command -v md5 &>/dev/null; then
+            checksum=$(md5 -q "${f}")
+        fi
+        local fname; fname=$(basename "${f}")
+        # JSON エントリをシェルで構築（jq 不要）
+        local entry
+        entry=$(printf '{"file":"%s","size_bytes":%s,"md5":"%s"}' \
+            "${fname}" "${size_bytes}" "${checksum}")
+        if [[ "${file_entries}" == "[]" ]]; then
+            file_entries="[${entry}]"
+        else
+            file_entries="${file_entries%]},${entry}]"
+        fi
+    done
+
+    local entry
+    entry=$(printf '{"timestamp":"%s","type":"%s","host":"%s","db_type":"%s","files":%s}' \
+        "${timestamp}" "${backup_type}" "${hostname}" "${DB_TYPE:-unknown}" "${file_entries}")
+
+    # 既存カタログに追記（簡易実装: 末尾の ] の前に挿入）
+    if [[ ! -f "${catalog_file}" ]]; then
+        echo "[${entry}]" > "${catalog_file}"
+    else
+        # 末尾の ] を取り除いて新エントリを追加
+        local existing; existing=$(cat "${catalog_file}")
+        if [[ "${existing}" == "[]" ]]; then
+            echo "[${entry}]" > "${catalog_file}"
+        else
+            echo "${existing%]},${entry}]" > "${catalog_file}"
+        fi
+    fi
+    log_info "カタログ更新: ${catalog_file}"
+}
+
 # ─── Slack 通知 ───────────────────────────────────────────────
 notify_slack() {
     local status="$1" message="$2"


### PR DESCRIPTION
## Summary

- `db_backup/lib.sh`: `update_backup_catalog()` 関数を追加（jq 不要、シェルのみで JSON 構築）
  - ファイルごとにサイズ（`stat`）と MD5 チェックサムを収集
  - `catalog.json` を新規作成または既存配列に追記
- `db_backup/backup.sh`: バックアップ完了後にカタログを更新

## Test plan

- [ ] フルバックアップ後に `${BACKUP_BASE_DIR}/catalog.json` が生成されることを確認
- [ ] 2回目のバックアップで JSON 配列にエントリが追記されることを確認
- [ ] `md5sum` / `md5` どちらもない環境でも動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_