### PR TITLE
feat: CoveringIndexRecommendation に confidence_score フィールドを追加

### DIFF
--- a/rds_analyzer/analyzers/index_analyzer.py
+++ b/rds_analyzer/analyzers/index_analyzer.py
@@ -167,6 +167,7 @@ class CoveringIndexAnalyzer:
             estimated_scan_ratio=round(ratio, 1),
             estimated_latency_improvement_pct=round(improvement_pct, 1),
             estimated_daily_rows_saved=round(daily_saved, 0),
+            confidence_score=self._confidence_score(query),
             create_statement_mysql=self._mysql_create(
                 query.table_name, idx_name, mysql_key_cols
             ),
@@ -261,6 +262,44 @@ class CoveringIndexAnalyzer:
             create_statement_mysql=self._mysql_create(table, idx_name, mysql_key),
             create_statement_postgresql=self._pg_create(table, idx_name, key_cols, include_cols, "postgresql"),
         )
+
+    # ----------------------------------------------------------
+    # 信頼スコア
+    # ----------------------------------------------------------
+
+    def _confidence_score(self, pattern: QueryPattern) -> float:
+        """
+        0.0–1.0 の信頼スコアを算出する。
+        実行回数・スキャン比率・レイテンシが高いほど信頼度が高い。
+        """
+        score = 0.0
+        ratio = pattern.avg_rows_examined / max(pattern.avg_rows_returned, 1)
+
+        # スキャン比率 (最大0.4)
+        if ratio >= 1000:
+            score += 0.4
+        elif ratio >= 100:
+            score += 0.3
+        elif ratio >= 10:
+            score += 0.2
+
+        # 実行頻度 (最大0.4)
+        if pattern.execution_count_per_day >= 1000:
+            score += 0.4
+        elif pattern.execution_count_per_day >= 100:
+            score += 0.3
+        elif pattern.execution_count_per_day >= 10:
+            score += 0.2
+        elif pattern.execution_count_per_day >= 1:
+            score += 0.1
+
+        # レイテンシ (最大0.2)
+        if pattern.avg_latency_ms >= 1000:
+            score += 0.2
+        elif pattern.avg_latency_ms >= 100:
+            score += 0.1
+
+        return round(min(score, 1.0), 2)
 
     # ----------------------------------------------------------
     # 優先度・理由文

--- a/rds_analyzer/models/index.py
+++ b/rds_analyzer/models/index.py
@@ -89,6 +89,7 @@ class CoveringIndexRecommendation(BaseModel):
     )
     estimated_latency_improvement_pct: float
     estimated_daily_rows_saved: float
+    confidence_score: float = 0.0
 
     create_statement_mysql: str = Field(description="MySQL/MariaDB 用 CREATE INDEX 文")
     create_statement_postgresql: str = Field(description="PostgreSQL 用 CREATE INDEX 文")

--- a/tests/test_index_analyzer.py
+++ b/tests/test_index_analyzer.py
@@ -484,3 +484,75 @@ class TestEdgeCases:
         result = analyzer.analyze(make_request([query], engine="postgresql"))
         if result.recommendations:
             assert result.recommendations[0].include_columns == []
+
+
+# ──────────────────────────────────────────────
+# 信頼スコアテスト
+# ──────────────────────────────────────────────
+
+class TestConfidenceScore:
+    def test_high_ratio_high_exec_high_latency_score_near_1(self):
+        """高スキャン比率 + 高実行頻度 + 高レイテンシ → スコアが 1.0 に近い"""
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["status"],
+            rows_examined=100000,
+            rows_returned=10,        # ratio = 10000 → +0.4
+            exec_per_day=5000,       # >= 1000      → +0.4
+            latency_ms=2000,         # >= 1000      → +0.2
+        )
+        result = analyzer.analyze(make_request([query]))
+        rec = result.recommendations[0]
+        assert rec.confidence_score >= 0.9
+
+    def test_low_ratio_low_exec_score_low(self):
+        """低スキャン比率 + 低実行頻度 → スコアが 0.3 以下"""
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["status"],
+            rows_examined=150,
+            rows_returned=10,        # ratio = 15 → +0.2
+            exec_per_day=5,          # >= 1       → +0.1
+            latency_ms=10,           # < 100      → +0.0
+        )
+        result = analyzer.analyze(make_request([query]))
+        rec = result.recommendations[0]
+        assert rec.confidence_score <= 0.3
+
+    def test_score_always_between_0_and_1(self):
+        """スコアは常に 0.0 以上 1.0 以下"""
+        analyzer = CoveringIndexAnalyzer()
+        cases = [
+            make_query(filter_cols=["a"], rows_examined=10, rows_returned=1,
+                       exec_per_day=0, latency_ms=0, query_id="q1"),
+            make_query(filter_cols=["b"], rows_examined=10000000, rows_returned=1,
+                       exec_per_day=999999, latency_ms=999999, query_id="q2"),
+        ]
+        for q in cases:
+            result = analyzer.analyze(make_request([q]))
+            if result.recommendations:
+                score = result.recommendations[0].confidence_score
+                assert 0.0 <= score <= 1.0, f"score={score} out of range for query {q.query_id}"
+
+    def test_score_increases_with_execution_count(self):
+        """実行回数が増えるほどスコアが上がる（または同じ）"""
+        analyzer = CoveringIndexAnalyzer()
+        base_kwargs = dict(
+            filter_cols=["status"],
+            rows_examined=500,
+            rows_returned=10,    # ratio = 50 → +0.2
+            latency_ms=50,       # < 100      → +0.0
+        )
+        q_low = make_query(**base_kwargs, exec_per_day=1, query_id="low")    # +0.1
+        q_mid = make_query(**base_kwargs, exec_per_day=50, query_id="mid")   # +0.2
+        q_high = make_query(**base_kwargs, exec_per_day=500, query_id="high") # +0.3
+
+        def get_score(q: QueryPattern) -> float:
+            res = analyzer.analyze(make_request([q]))
+            return res.recommendations[0].confidence_score if res.recommendations else 0.0
+
+        score_low = get_score(q_low)
+        score_mid = get_score(q_mid)
+        score_high = get_score(q_high)
+
+        assert score_low <= score_mid <= score_high


### PR DESCRIPTION
## Summary

- `CoveringIndexRecommendation.confidence_score: float` フィールドを追加（0.0–1.0）
- `CoveringIndexAnalyzer._confidence_score()` メソッドを追加
  - スキャン比率（最大 0.4）+ 実行頻度（最大 0.4）+ レイテンシ（最大 0.2）で算出
- `_build_recommendation()` で `confidence_score` を設定するよう修正
- `TestConfidenceScore` (4テスト) を追加

## Test plan

- [ ] `python -m pytest tests/test_index_analyzer.py -v` — 34テスト全件パス
- [ ] 高スキャン比 + 高頻度 + 高レイテンシで score ≥ 0.9 を確認
- [ ] score が常に [0.0, 1.0] 範囲内であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_