### PR TITLE
feat: CoveringIndexAnalyzer のしきい値をコンストラクタで設定可能にする

### DIFF
--- a/rds_analyzer/analyzers/index_analyzer.py
+++ b/rds_analyzer/analyzers/index_analyzer.py
@@ -43,7 +43,17 @@ _FREQ_MEDIUM = 100.0
 class CoveringIndexAnalyzer:
     """カバリングインデックス分析エンジン（純粋計算クラス、I/O なし）"""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        ratio_critical: float = 1000.0,
+        ratio_high: float = 100.0,
+        ratio_medium: float = 10.0,
+        min_exec_count_per_day: float = 0.0,
+    ) -> None:
+        self._ratio_critical = ratio_critical
+        self._ratio_high = ratio_high
+        self._ratio_medium = ratio_medium
+        self._min_exec_count_per_day = min_exec_count_per_day
         self._counter = 0
 
     # ----------------------------------------------------------
@@ -66,6 +76,15 @@ class CoveringIndexAnalyzer:
         needing_count = 0
 
         for query in request.queries:
+            if query.execution_count_per_day < self._min_exec_count_per_day:
+                logger.debug(
+                    "クエリ '%s' は実行頻度 %.1f/日 が最小閾値 %.1f/日 未満のためスキップ",
+                    query.query_id or query.table_name,
+                    query.execution_count_per_day,
+                    self._min_exec_count_per_day,
+                )
+                continue
+
             if self._is_covered(query, request.existing_indexes):
                 covered_count += 1
                 logger.debug("クエリ '%s' は既存インデックスでカバー済み", query.query_id or query.table_name)
@@ -137,7 +156,7 @@ class CoveringIndexAnalyzer:
             return None  # WHERE 句なし: インデックスでフルスキャンを解消できない
 
         ratio = query.avg_rows_examined / max(query.avg_rows_returned, 1.0)
-        if ratio < _RATIO_MEDIUM:
+        if ratio < self._ratio_medium:
             return None  # スキャン比率が小さく改善余地が少ない
 
         # キーカラム: filter → sort → group (重複除去・順序維持)
@@ -267,11 +286,11 @@ class CoveringIndexAnalyzer:
     # ----------------------------------------------------------
 
     def _priority(self, ratio: float, daily_exec: float) -> str:
-        if ratio >= _RATIO_CRITICAL and daily_exec >= _FREQ_MEDIUM:
+        if ratio >= self._ratio_critical and daily_exec >= _FREQ_MEDIUM:
             return "critical"
-        if ratio >= _RATIO_HIGH or (ratio >= _RATIO_MEDIUM and daily_exec >= _FREQ_HIGH):
+        if ratio >= self._ratio_high or (ratio >= self._ratio_medium and daily_exec >= _FREQ_HIGH):
             return "high"
-        if ratio >= _RATIO_MEDIUM or daily_exec >= _FREQ_MEDIUM:
+        if ratio >= self._ratio_medium or daily_exec >= _FREQ_MEDIUM:
             return "medium"
         return "low"
 

--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -694,6 +694,8 @@ async def generate_report(
 async def analyze_covering_indexes(
     instance_id: str,
     body: IndexAnalysisApiRequest,
+    ratio_medium: float = Query(default=10.0, ge=1.0, description="medium 優先度のスキャン比率閾値"),
+    min_exec_count: float = Query(default=0.0, ge=0.0, description="分析対象とする最小実行頻度（1日あたり）"),
 ) -> IndexAnalysisResponse:
     """
     クエリパターンと既存インデックスを分析してカバリングインデックスを推奨する
@@ -726,7 +728,7 @@ async def analyze_covering_indexes(
         ],
     )
 
-    analyzer = CoveringIndexAnalyzer()
+    analyzer = CoveringIndexAnalyzer(ratio_medium=ratio_medium, min_exec_count_per_day=min_exec_count)
     result = analyzer.analyze(request)
 
     # 分析結果をキャッシュ

--- a/tests/test_index_analyzer.py
+++ b/tests/test_index_analyzer.py
@@ -484,3 +484,109 @@ class TestEdgeCases:
         result = analyzer.analyze(make_request([query], engine="postgresql"))
         if result.recommendations:
             assert result.recommendations[0].include_columns == []
+
+
+# ──────────────────────────────────────────────
+# コンストラクタしきい値テスト
+# ──────────────────────────────────────────────
+
+class TestConfigurableThresholds:
+    """CoveringIndexAnalyzer のコンストラクタ経由のしきい値設定テスト"""
+
+    def test_default_thresholds_trigger_at_ratio_10(self):
+        """デフォルトしきい値（ratio_medium=10）では ratio=10 で推奨が生成される"""
+        analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["status"],
+            rows_examined=100,
+            rows_returned=10,   # ratio = 10.0 (ちょうど閾値)
+            exec_per_day=5,
+        )
+        result = analyzer.analyze(make_request([query]))
+        assert len(result.recommendations) == 1
+
+    def test_custom_ratio_medium_suppresses_low_ratio(self):
+        """ratio_medium=50 に設定すると ratio=30 では推奨が生成されない"""
+        analyzer = CoveringIndexAnalyzer(ratio_medium=50.0)
+        query = make_query(
+            filter_cols=["status"],
+            rows_examined=300,
+            rows_returned=10,   # ratio = 30.0 < 50
+            exec_per_day=50,
+        )
+        result = analyzer.analyze(make_request([query]))
+        assert result.recommendations == []
+
+    def test_custom_ratio_medium_still_triggers_above_threshold(self):
+        """ratio_medium=50 でも ratio=60 なら推奨が生成される"""
+        analyzer = CoveringIndexAnalyzer(ratio_medium=50.0)
+        query = make_query(
+            filter_cols=["status"],
+            rows_examined=600,
+            rows_returned=10,   # ratio = 60.0 >= 50
+            exec_per_day=50,
+        )
+        result = analyzer.analyze(make_request([query]))
+        assert len(result.recommendations) == 1
+
+    def test_min_exec_count_per_day_filters_low_frequency(self):
+        """min_exec_count_per_day=10 に設定すると exec_per_day=5 のクエリはスキップされる"""
+        analyzer = CoveringIndexAnalyzer(min_exec_count_per_day=10.0)
+        query = make_query(
+            filter_cols=["status"],
+            rows_examined=10000,
+            rows_returned=10,   # ratio = 1000 (高い)
+            exec_per_day=5,     # < 10 → スキップ
+        )
+        result = analyzer.analyze(make_request([query]))
+        assert result.recommendations == []
+        assert result.total_queries_analyzed == 1
+        assert result.queries_needing_index == 0
+
+    def test_min_exec_count_per_day_passes_high_frequency(self):
+        """min_exec_count_per_day=10 でも exec_per_day=20 なら分析対象になる"""
+        analyzer = CoveringIndexAnalyzer(min_exec_count_per_day=10.0)
+        query = make_query(
+            filter_cols=["status"],
+            rows_examined=10000,
+            rows_returned=10,   # ratio = 1000
+            exec_per_day=20,    # >= 10 → 分析対象
+        )
+        result = analyzer.analyze(make_request([query]))
+        assert len(result.recommendations) == 1
+
+    def test_ratio_critical_affects_priority_assignment(self):
+        """ratio_critical を下げると、低い ratio でも critical 優先度になる"""
+        # デフォルト: ratio=200, exec=200/日 → ratio < 1000 なので critical にならない
+        default_analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["status"],
+            rows_examined=2000,
+            rows_returned=10,   # ratio = 200
+            exec_per_day=200,
+        )
+        result_default = default_analyzer.analyze(make_request([query]))
+        assert result_default.recommendations[0].priority == "high"
+
+        # ratio_critical=100 に下げると ratio=200 >= 100 かつ exec=200 >= 100 → critical
+        custom_analyzer = CoveringIndexAnalyzer(ratio_critical=100.0)
+        result_custom = custom_analyzer.analyze(make_request([query]))
+        assert result_custom.recommendations[0].priority == "critical"
+
+    def test_ratio_high_affects_priority_assignment(self):
+        """ratio_high を上げると、従来 high だったものが medium に落ちる"""
+        # ratio=150, exec=5/日: デフォルト ratio_high=100 では ratio >= 100 → high
+        default_analyzer = CoveringIndexAnalyzer()
+        query = make_query(
+            filter_cols=["category"],
+            rows_examined=1500,
+            rows_returned=10,   # ratio = 150
+            exec_per_day=5,
+        )
+        result_default = default_analyzer.analyze(make_request([query]))
+        assert result_default.recommendations[0].priority == "high"
+
+        # ratio_high=200 に上げると ratio=150 < 200 → high にならず medium
+        custom_analyzer = CoveringIndexAnalyzer(ratio_high=200.0)
+        result_custom = custom_analyzer.analyze(make_request([query]))
+        assert result_custom.recommendations[0].priority == "medium"


### PR DESCRIPTION
## Summary

- `CoveringIndexAnalyzer.__init__()` に `ratio_critical`, `ratio_high`, `ratio_medium`, `min_exec_count_per_day` パラメータを追加（デフォルト値は既存定数と同じ）
- `analyze()` で `min_exec_count_per_day` 未満のパターンをスキップ
- `POST /rds/{id}/index-analysis` に `ratio_medium` と `min_exec_count` クエリパラメータを追加
- `TestConfigurableThresholds` (7テスト) を追加

## Test plan

- [ ] `python -m pytest tests/test_index_analyzer.py -v` — 37テスト全件パス
- [ ] `python -m pytest tests/test_api.py -v` — 34テスト全件パス
- [ ] `ratio_medium=50` 指定時に比率30のパターンが推奨されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_