### PR TITLE
feat: add zstd compression support with gzip fallback in backup scripts

### DIFF
--- a/db_backup/config.sh
+++ b/db_backup/config.sh
@@ -54,6 +54,9 @@ INCREMENTAL_RETENTION_DAYS=3
 # ─── 圧縮設定 ─────────────────────────────────────────────────
 COMPRESS=true
 COMPRESS_LEVEL=6
+# COMPRESS_FORMAT: gzip（デフォルト）または zstd
+# zstd は gzip より高速かつ高圧縮率だが、zstd コマンドが必要
+COMPRESS_FORMAT="${COMPRESS_FORMAT:-gzip}"
 
 # ─── Slack 通知 ───────────────────────────────────────────────
 SLACK_WEBHOOK_URL=""

--- a/db_backup/lib.sh
+++ b/db_backup/lib.sh
@@ -67,21 +67,54 @@ pg_env() {
 compress_file() {
     local f="$1"
     [[ "${COMPRESS}" != "true" || ! -f "${f}" ]] && return 0
+
+    local fmt="${COMPRESS_FORMAT:-gzip}"
+
+    if [[ "${fmt}" == "zstd" ]]; then
+        if command -v zstd &>/dev/null; then
+            zstd -"${COMPRESS_LEVEL}" --rm -q "${f}"
+            log_info "圧縮完了 (zstd): ${f}.zst"
+            return 0
+        fi
+        log_warn "zstd が見つかりません。gzip にフォールバックします。"
+    fi
+
     gzip -"${COMPRESS_LEVEL}" "${f}"
-    log_info "圧縮完了: ${f}.gz"
+    log_info "圧縮完了 (gzip): ${f}.gz"
+}
+
+# 圧縮後のファイル拡張子を返す
+compress_ext() {
+    local fmt="${COMPRESS_FORMAT:-gzip}"
+    if [[ "${fmt}" == "zstd" ]] && command -v zstd &>/dev/null; then
+        echo "zst"
+    else
+        echo "gz"
+    fi
 }
 
 # ─── バックアップ整合性検証 ───────────────────────────────────
+# 圧縮形式を自動判別してテストする
+_verify_compressed_file() {
+    local f="$1"
+    case "${f}" in
+        *.zst) zstd -t -q "${f}" 2>/dev/null ;;
+        *.gz)  gzip -t "${f}" 2>/dev/null ;;
+        *)     return 0 ;;
+    esac
+}
+
 verify_backup_files() {
     local dir="$1"
-    local pattern="${2:-*.sql.gz}"
+    local ext; ext="$(compress_ext)"
+    local pattern="${2:-*.sql.${ext}}"
     local failed=0
     local checked=0
 
     log_info "バックアップ整合性検証: ${dir}/${pattern}"
 
     while IFS= read -r f; do
-        if gzip -t "${f}" 2>/dev/null; then
+        if _verify_compressed_file "${f}"; then
             log_info "  OK: $(basename "${f}")"
         else
             log_error "  NG (破損): $(basename "${f}")"


### PR DESCRIPTION
## Summary

- Add `COMPRESS_FORMAT` env var to `db_backup/config.sh` (default: `gzip`, also accepts `zstd`)
- `compress_file()` in `lib.sh` now uses `zstd` when `COMPRESS_FORMAT=zstd` and the binary is available; gracefully falls back to `gzip` with a warning if `zstd` is not installed
- Add `compress_ext()` helper returning `"zst"` or `"gz"` depending on the active format
- Add `_verify_compressed_file()` for format-aware integrity checking (handles both `.gz` and `.zst`)
- `verify_backup_files()` now uses `compress_ext()` to auto-select the glob pattern

## Test plan

- [ ] `bash -n db_backup/lib.sh && bash -n db_backup/config.sh` — syntax OK
- [ ] `COMPRESS_FORMAT=zstd` execution selects zstd when available, falls back to gzip otherwise

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_