### PR TITLE
feat: group recommendations by type in Markdown report output

### DIFF
--- a/rds_analyzer/report_generator.py
+++ b/rds_analyzer/report_generator.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
-from .analyzers.recommendation_engine import Recommendation, RecommendationPriority
+from .analyzers.recommendation_engine import Recommendation, RecommendationPriority, RecommendationType
 from .models.costs import CostBreakdown, CostEfficiencyScore
 from .models.metrics import PerformanceAnalysisResult, PerformanceStatus
 from .models.rds import RDSInstance
@@ -42,6 +42,21 @@ PRIORITY_EMOJI = {
     RecommendationPriority.HIGH: "🟠",
     RecommendationPriority.MEDIUM: "🟡",
     RecommendationPriority.LOW: "⚪",
+}
+
+# 提案種別ごとのセクション見出し（日本語）
+TYPE_LABEL = {
+    RecommendationType.SCALE_UP: "スケールアップ",
+    RecommendationType.SCALE_DOWN: "スケールダウン（コスト最適化）",
+    RecommendationType.STORAGE_TYPE_CHANGE: "ストレージ最適化",
+    RecommendationType.ADD_READ_REPLICA: "読み取り負荷分散",
+    RecommendationType.AURORA_MIGRATION: "Aurora 移行",
+    RecommendationType.AURORA_SERVERLESS: "Aurora Serverless 化",
+    RecommendationType.ENABLE_MULTI_AZ: "可用性向上",
+    RecommendationType.OPTIMIZE_BACKUP: "バックアップ最適化",
+    RecommendationType.UPGRADE_GRAVITON: "Graviton インスタンス移行",
+    RecommendationType.REDUCE_CONNECTIONS: "コネクション管理",
+    RecommendationType.ADD_COVERING_INDEX: "インデックス最適化",
 }
 
 
@@ -221,23 +236,33 @@ class ReportGenerator:
             max(0, r.estimated_monthly_savings_usd) for r in recommendations
         )
 
+        # 提案種別でグループ化
+        from collections import defaultdict
+        groups: dict[RecommendationType, list[Recommendation]] = defaultdict(list)
+        for rec in recommendations:
+            groups[rec.type].append(rec)
+
         recs_md = ""
-        for i, rec in enumerate(recommendations, 1):
-            priority_emoji = PRIORITY_EMOJI[rec.priority]
-            savings_str = (
-                f"💰 ${rec.estimated_monthly_savings_usd:.1f}/月 節約"
-                if rec.estimated_monthly_savings_usd > 0
-                else f"📈 ${abs(rec.estimated_monthly_savings_usd):.1f}/月 追加コスト"
-                if rec.estimated_monthly_savings_usd < 0
-                else "効果: パフォーマンス改善"
-            )
+        item_num = 1
+        for rec_type, group_recs in groups.items():
+            group_label = TYPE_LABEL.get(rec_type, rec_type.value)
+            recs_md += f"\n### カテゴリ: {group_label}\n"
+            for rec in group_recs:
+                priority_emoji = PRIORITY_EMOJI[rec.priority]
+                savings_str = (
+                    f"💰 ${rec.estimated_monthly_savings_usd:.1f}/月 節約"
+                    if rec.estimated_monthly_savings_usd > 0
+                    else f"📈 ${abs(rec.estimated_monthly_savings_usd):.1f}/月 追加コスト"
+                    if rec.estimated_monthly_savings_usd < 0
+                    else "効果: パフォーマンス改善"
+                )
 
-            steps_md = "\n".join(
-                f"   {j}. {step}" for j, step in enumerate(rec.action_steps, 1)
-            ) if rec.action_steps else ""
+                steps_md = "\n".join(
+                    f"   {j}. {step}" for j, step in enumerate(rec.action_steps, 1)
+                ) if rec.action_steps else ""
 
-            recs_md += f"""
-### {i}. {priority_emoji} {rec.title}
+                recs_md += f"""
+#### {item_num}. {priority_emoji} {rec.title}
 
 - **優先度**: {rec.priority.value.upper()} | **種別**: {rec.type.value}
 - **効果**: {savings_str}
@@ -253,6 +278,7 @@ class ReportGenerator:
 
 {steps_md}
 """
+                item_num += 1
 
         return f"""## 改善提案 ({len(recommendations)} 件)
 

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -190,3 +190,90 @@ class TestReportSave:
         out = tmp_path / "nested" / "dir" / "report.md"
         generator.save(md, out)
         assert out.exists()
+
+
+class TestRecommendationGroups:
+    """提案のグループ化テスト"""
+
+    def test_recommendations_grouped_by_type(self, generator, instance):
+        """同種別の提案が同じカテゴリ見出し配下にまとめられる"""
+        from rds_analyzer.analyzers.recommendation_engine import (
+            Recommendation, RecommendationPriority, RecommendationType,
+        )
+        recs = [
+            Recommendation(
+                recommendation_id="rec_001",
+                type=RecommendationType.SCALE_DOWN,
+                priority=RecommendationPriority.MEDIUM,
+                title="インスタンスクラス縮小",
+                description="CPU利用率が低い",
+                current_config="db.r5.xlarge",
+                recommended_config="db.r5.large",
+                estimated_monthly_savings_usd=150.0,
+                implementation_complexity=2,
+            ),
+            Recommendation(
+                recommendation_id="rec_002",
+                type=RecommendationType.STORAGE_TYPE_CHANGE,
+                priority=RecommendationPriority.LOW,
+                title="gp3 への移行",
+                description="コスト削減",
+                current_config="gp2",
+                recommended_config="gp3",
+                estimated_monthly_savings_usd=20.0,
+                implementation_complexity=1,
+            ),
+            Recommendation(
+                recommendation_id="rec_003",
+                type=RecommendationType.SCALE_DOWN,
+                priority=RecommendationPriority.LOW,
+                title="バックアップ期間短縮",
+                description="30日から7日へ",
+                current_config="30日",
+                recommended_config="7日",
+                estimated_monthly_savings_usd=10.0,
+                implementation_complexity=1,
+            ),
+        ]
+        from rds_analyzer.analyzers.cost_analyzer import CostAnalyzer
+        from rds_analyzer.analyzers.performance_analyzer import PerformanceAnalyzer
+        from tests.rds_conftest import make_metrics
+        cost_analyzer = CostAnalyzer()
+        perf_analyzer = PerformanceAnalyzer()
+        metrics = make_metrics(instance.instance_id, cpu_avg=40.0, cpu_max=65.0)
+        breakdown, _ = cost_analyzer.calculate_monthly_cost(instance)
+        cost_score = cost_analyzer.calculate_efficiency_score(
+            instance, breakdown,
+            avg_cpu_pct=metrics.cpu_utilization.avg,
+            avg_iops_used=metrics.read_iops.avg + metrics.write_iops.avg,
+            storage_used_gb=instance.allocated_storage_gb - metrics.free_storage_bytes.avg / (1024**3),
+        )
+        perf_result = perf_analyzer.analyze(instance, metrics)
+
+        md = generator.generate(instance, breakdown, cost_score, perf_result, recs)
+        # カテゴリ見出しが含まれることを確認
+        assert "### カテゴリ:" in md
+        # SCALE_DOWN が1グループにまとまること（2件）
+        scale_down_idx = md.index("スケールダウン")
+        assert "インスタンスクラス縮小" in md[scale_down_idx:]
+
+    def test_empty_recommendations_no_category_headers(self, generator, instance):
+        """提案なしのとき カテゴリ見出しが出力されない"""
+        from rds_analyzer.analyzers.cost_analyzer import CostAnalyzer
+        from rds_analyzer.analyzers.performance_analyzer import PerformanceAnalyzer
+        from tests.rds_conftest import make_metrics
+        cost_analyzer = CostAnalyzer()
+        perf_analyzer = PerformanceAnalyzer()
+        metrics = make_metrics(instance.instance_id, cpu_avg=40.0, cpu_max=65.0)
+        breakdown, _ = cost_analyzer.calculate_monthly_cost(instance)
+        cost_score = cost_analyzer.calculate_efficiency_score(
+            instance, breakdown,
+            avg_cpu_pct=metrics.cpu_utilization.avg,
+            avg_iops_used=metrics.read_iops.avg + metrics.write_iops.avg,
+            storage_used_gb=instance.allocated_storage_gb - metrics.free_storage_bytes.avg / (1024**3),
+        )
+        perf_result = perf_analyzer.analyze(instance, metrics)
+
+        md = generator.generate(instance, breakdown, cost_score, perf_result, [])
+        assert "### カテゴリ:" not in md
+        assert "現時点での改善提案はありません" in md


### PR DESCRIPTION
## Summary

- Import `RecommendationType` in `report_generator.py`
- Add `TYPE_LABEL` dict mapping each `RecommendationType` to a Japanese section title
- `_recommendations_section()` now groups recommendations by type using `defaultdict`, emitting a `### カテゴリ: <label>` sub-header per group before listing individual items as `####` entries
- Add `TestRecommendationGroups` (2 tests) verifying grouping behavior and the empty-recommendation case

## Test plan

- [ ] `python -m pytest tests/test_report_generator.py -v` — all 18 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_