### PR TITLE
test: add PerformanceAnalyzer edge cases (gp2/gp3/io1 IOPS, CPU, engine, Multi-AZ)

### DIFF
--- a/tests/test_performance_analyzer.py
+++ b/tests/test_performance_analyzer.py
@@ -200,3 +200,109 @@ class TestHealthScore:
         metrics = make_healthy_metrics()
         result = perf_analyzer.analyze(base_instance, metrics)
         assert 0 <= result.health_score <= 100
+
+
+def make_metrics_for(instance_id: str, **kwargs) -> MetricsHistory:
+    """指定した値でメトリクスを作成するヘルパー"""
+    cpu_avg = kwargs.get("cpu_avg", 40.0)
+    cpu_max = kwargs.get("cpu_max", 65.0)
+    mem_avg = kwargs.get("mem_avg", 3.5)
+    iops_avg = kwargs.get("iops_avg", 300.0)
+    conns_avg = kwargs.get("conns_avg", 80.0)
+    free_storage_gb = kwargs.get("free_storage_gb", 50.0)
+    gb = 1024 ** 3
+
+    now = datetime.now(tz=timezone.utc)
+    return MetricsHistory(
+        instance_id=instance_id,
+        period_start=now - timedelta(hours=24),
+        period_end=now,
+        cpu_utilization=make_stats(cpu_avg, cpu_max),
+        freeable_memory_bytes=make_stats(mem_avg * gb, mem_avg * gb * 1.2, mem_avg * gb * 0.8),
+        read_iops=make_stats(iops_avg * 0.6, iops_avg),
+        write_iops=make_stats(iops_avg * 0.4, iops_avg * 0.7),
+        read_latency_ms=make_stats(5.0, 15.0),
+        write_latency_ms=make_stats(6.0, 18.0),
+        database_connections=make_stats(conns_avg, conns_avg * 1.5),
+        free_storage_bytes=make_stats(
+            free_storage_gb * gb,
+            free_storage_gb * gb * 1.1,
+            free_storage_gb * gb * 0.9,
+        ),
+        disk_queue_depth=make_stats(0.2, 1.0),
+        network_receive_bps=make_stats(1_000_000, 5_000_000),
+        network_transmit_bps=make_stats(1_000_000, 5_000_000),
+    )
+
+
+class TestPerformanceAnalyzerEdgeCases:
+    """PerformanceAnalyzer 境界値・エッジケーステスト"""
+
+    def test_gp2_iops_baseline_100gb(self, perf_analyzer, base_instance):
+        """gp2 100GB: IOPS上限 = max(100, 100*3) = 300"""
+        base_instance.allocated_storage_gb = 100
+        assert perf_analyzer.get_iops_limit(base_instance) == 300
+
+    def test_gp2_iops_minimum_at_33gb(self, perf_analyzer, base_instance):
+        """gp2 33GB: 33*3=99 < 100 なので最小値 100"""
+        base_instance.allocated_storage_gb = 33
+        assert perf_analyzer.get_iops_limit(base_instance) == 100
+
+    def test_gp2_iops_capped_at_16000(self, perf_analyzer, base_instance):
+        """gp2 6000GB: 6000*3=18000 > 16000 なので上限 16000"""
+        base_instance.allocated_storage_gb = 6000
+        assert perf_analyzer.get_iops_limit(base_instance) == 16000
+
+    def test_gp3_default_iops_3000(self, perf_analyzer, base_instance):
+        """gp3 プロビジョンドなし: デフォルト 3000 IOPS"""
+        base_instance.storage_type = StorageType.GP3
+        base_instance.provisioned_iops = None
+        assert perf_analyzer.get_iops_limit(base_instance) == 3000
+
+    def test_gp3_provisioned_iops_respected(self, perf_analyzer, base_instance):
+        """gp3 プロビジョンド 6000: そのまま返す"""
+        base_instance.storage_type = StorageType.GP3
+        base_instance.provisioned_iops = 6000
+        assert perf_analyzer.get_iops_limit(base_instance) == 6000
+
+    def test_io1_provisioned_iops(self, perf_analyzer, base_instance):
+        """io1 3000 IOPS プロビジョンド: 3000 を返す"""
+        base_instance.storage_type = StorageType.IO1
+        base_instance.provisioned_iops = 3000
+        assert perf_analyzer.get_iops_limit(base_instance) == 3000
+
+    def test_high_cpu_status_critical(self, perf_analyzer, base_instance):
+        """CPU 95% は CRITICAL ステータス"""
+        metrics = make_metrics_for(base_instance.instance_id, cpu_avg=95.0, cpu_max=98.0)
+        result = perf_analyzer.analyze(base_instance, metrics)
+        from rds_analyzer.models.metrics import PerformanceStatus
+        assert result.cpu_status == PerformanceStatus.CRITICAL
+
+    def test_zero_cpu_status_warning_or_healthy(self, perf_analyzer, base_instance):
+        """CPU 0% は異常ではないが、健全性スコアには影響しない"""
+        metrics = make_metrics_for(base_instance.instance_id, cpu_avg=0.0, cpu_max=0.5)
+        result = perf_analyzer.analyze(base_instance, metrics)
+        assert result.health_score >= 0
+
+    def test_postgresql_engine_analyze(self, perf_analyzer):
+        """PostgreSQL エンジンでも分析が正常に動作する"""
+        pg_instance = RDSInstance(
+            instance_id="test-pg-edge",
+            engine=EngineType.POSTGRESQL,
+            engine_version="15.4",
+            instance_class="db.r5.large",
+            region="ap-northeast-1",
+            storage_type=StorageType.GP3,
+            allocated_storage_gb=200,
+        )
+        metrics = make_metrics_for(pg_instance.instance_id)
+        result = perf_analyzer.analyze(pg_instance, metrics)
+        assert 0 <= result.health_score <= 100
+        assert result.iops_limit_pct >= 0
+
+    def test_multi_az_instance_analyze(self, perf_analyzer, base_instance):
+        """Multi-AZ インスタンスでも分析が正常に動作する"""
+        base_instance.multi_az = True
+        metrics = make_metrics_for(base_instance.instance_id)
+        result = perf_analyzer.analyze(base_instance, metrics)
+        assert 0 <= result.health_score <= 100


### PR DESCRIPTION
## Summary

- Add `make_metrics_for()` helper with kwarg-based metric overrides (`cpu_avg`, `cpu_max`, `mem_avg`, `iops_avg`, etc.)
- Add `TestPerformanceAnalyzerEdgeCases` class with 10 tests:
  - gp2 IOPS baseline formula: 100GB → 300, 33GB → 100 (min), 6000GB → 16000 (cap)
  - gp3 default IOPS (3000) and provisioned IOPS passthrough
  - io1 provisioned IOPS passthrough
  - High CPU (95%) → `CRITICAL` status
  - Zero CPU → valid health score without crash
  - PostgreSQL engine analysis works end-to-end
  - Multi-AZ instance analysis works end-to-end

## Test plan

- [ ] `python -m pytest tests/test_performance_analyzer.py -v` — all 25 tests pass (15 existing + 10 new)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_