### PR TITLE
refactor: A/Bテストのバリアント選択をMD5からSHA-256に変更

### DIFF
--- a/project/app/api/metrics.py
+++ b/project/app/api/metrics.py
@@ -41,6 +41,12 @@ except ImportError:  # pragma: no cover
 
 # ---- メトリクス定義 ----
 
+# モジュールレベルで初期化（prometheus 非インストール時も属性として存在させる）
+PREDICT_REQUESTS = None
+PREDICT_LATENCY = None
+MODEL_INFO = None
+MODEL_LOADED = None
+
 if _PROMETHEUS_AVAILABLE:
     # 予測リクエスト総数（status=success/error でラベル分け）
     PREDICT_REQUESTS = Counter(

--- a/project/app/model/ab_test.py
+++ b/project/app/model/ab_test.py
@@ -116,7 +116,7 @@ class ABTestRouter:
             選択された VariantRecord
         """
         # ハッシュ値を 0.0〜1.0 に変換
-        h = int(hashlib.md5(race_id.encode()).hexdigest(), 16)
+        h = int(hashlib.sha256(race_id.encode()).hexdigest(), 16)
         normalized = (h % 10000) / 10000.0
 
         # 重みを正規化して累積区間を作成


### PR DESCRIPTION
## 変更内容

- `app/model/ab_test.py`: `_select_variant()` 内のトラフィックルーティングハッシュを `hashlib.md5` → `hashlib.sha256` に変更
- `app/api/metrics.py`: prometheus-client 未インストール環境でのテスト `AttributeError` を防ぐモジュールレベルの `None` スタブを追加

## 背景

MD5 は衝突耐性が低く非推奨のハッシュアルゴリズム。A/Bテストのバリアント選択では暗号的強度は必要ないが、コードベース全体のハッシュアルゴリズムを SHA-256 に統一する方針に合わせる。

決定論的な性質（同じ `race_id` → 同じバリアント）は SHA-256 でも完全に維持される。

## テスト

- 688 テスト全件パス確認済み

---
_Generated by [Claude Code](https://claude.ai/code/session_0196RVKz1T6WkTD5dMrTXBBy)_