### PR TITLE
feat: GET /recommendations に ?priority= フィルタを追加

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -483,6 +483,10 @@ async def get_recommendations(
     data_transfer_gb: float = Query(default=0.0, ge=0),
     limit: int = Query(default=20, ge=1, le=100, description="1ページあたりの件数"),
     offset: int = Query(default=0, ge=0, description="スキップする件数"),
+    priority: Optional[str] = Query(
+        default=None,
+        description="優先度フィルタ (critical/high/medium/low)。複数指定はカンマ区切り",
+    ),
     cost_analyzer: CostAnalyzer = Depends(get_cost_analyzer),
     perf_analyzer: PerformanceAnalyzer = Depends(get_performance_analyzer),
     rec_engine: RecommendationEngine = Depends(get_recommendation_engine),
@@ -492,15 +496,36 @@ async def get_recommendations(
 
     優先度（CRITICAL > HIGH > MEDIUM > LOW）順に、
     コスト削減・パフォーマンス改善の提案を返す
+
+    `?priority=critical` または `?priority=critical,high` で絞り込み可能
     """
     instance = get_instance_or_404(instance_id)
     metrics = get_metrics_or_404(instance_id)
+
+    # 優先度フィルタのパース
+    priority_filter: Optional[set[str]] = None
+    if priority:
+        allowed = {"critical", "high", "medium", "low"}
+        values = {p.strip().lower() for p in priority.split(",")}
+        invalid = values - allowed
+        if invalid:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"無効な priority 値: {', '.join(sorted(invalid))}。critical/high/medium/low から選択してください",
+            )
+        priority_filter = values
 
     breakdown, _ = cost_analyzer.calculate_monthly_cost(
         instance, data_transfer_gb=data_transfer_gb
     )
     perf_result = perf_analyzer.analyze(instance, metrics)
     recommendations = rec_engine.generate_recommendations(instance, perf_result, breakdown)
+
+    # 優先度フィルタを適用
+    if priority_filter:
+        recommendations = [
+            r for r in recommendations if r.priority.value.lower() in priority_filter
+        ]
 
     total_savings = sum(
         max(0, r.estimated_monthly_savings_usd) for r in recommendations

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -160,6 +160,66 @@ class TestAnalysis:
         assert isinstance(data["recommendations"], list)
 
 
+class TestRecommendationPriorityFilter:
+    """?priority= クエリパラメータによる推奨絞り込みのテスト"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post(
+            "/api/v1/rds/test-api-mysql-001/metrics", json=sample_metrics_payload
+        )
+
+    def test_no_filter_returns_all(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/recommendations")
+        assert resp.status_code == 200
+        all_count = resp.json()["total_recommendations"]
+        # フィルタなしは全件返す
+        assert all_count >= 0
+
+    def test_filter_valid_priority(self, client):
+        for prio in ("critical", "high", "medium", "low"):
+            resp = client.get(
+                f"/api/v1/rds/test-api-mysql-001/recommendations?priority={prio}"
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            for item in data["recommendations"]:
+                assert item["priority"].lower() == prio
+
+    def test_filter_multi_priority(self, client):
+        resp = client.get(
+            "/api/v1/rds/test-api-mysql-001/recommendations?priority=high,medium"
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        for item in data["recommendations"]:
+            assert item["priority"].lower() in ("high", "medium")
+
+    def test_filter_invalid_priority_returns_422(self, client):
+        resp = client.get(
+            "/api/v1/rds/test-api-mysql-001/recommendations?priority=urgent"
+        )
+        assert resp.status_code == 422
+
+    def test_filter_case_insensitive(self, client):
+        resp = client.get(
+            "/api/v1/rds/test-api-mysql-001/recommendations?priority=HIGH"
+        )
+        assert resp.status_code == 200
+
+    def test_total_count_matches_filtered_results(self, client):
+        resp_all = client.get("/api/v1/rds/test-api-mysql-001/recommendations")
+        resp_filtered = client.get(
+            "/api/v1/rds/test-api-mysql-001/recommendations?priority=low"
+        )
+        assert resp_all.status_code == 200
+        assert resp_filtered.status_code == 200
+        # フィルタ後の total_recommendations はフィルタ済み件数
+        filtered_count = resp_filtered.json()["total_recommendations"]
+        assert filtered_count <= resp_all.json()["total_recommendations"]
+
+
 class TestSummary:
     def test_empty_summary(self, client):
         """インスタンス未登録でも空リストが返る"""


### PR DESCRIPTION
## 概要

`GET /rds/{id}/recommendations` に `?priority=` クエリパラメータを追加し、優先度による絞り込みを可能にします。

## 変更内容

### `rds_analyzer/api/routes.py`
- `priority: Optional[str]` クエリパラメータを追加
- `critical/high/medium/low` の単一指定・カンマ区切り複数指定をサポート
- 不正な値 → 422 Unprocessable Content
- フィルタ後の `total_recommendations` はフィルタ済み件数を返す

### `tests/test_api.py`
- `TestRecommendationPriorityFilter` クラスを追加（6 テスト）
  - フィルタなし → 全件返却
  - 各優先度ごとに返却アイテムの priority が一致することを確認
  - カンマ区切り複数指定
  - 不正値 → 422
  - 大文字小文字を区別しない (`?priority=HIGH` → 200)
  - フィルタ後の `total_recommendations` ≤ 全件数


---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_