### PR TITLE
feat: GET /rds インスタンス一覧エンドポイント追加

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,48 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+    InstanceListItem,
+    InstanceListResponse,
+@router.get(
+    "/rds",
+    response_model=InstanceListResponse,
+    tags=["instances"],
+    summary="登録済み RDS インスタンス一覧を取得",
+)
+async def list_instances(
+    engine: Optional[str] = Query(default=None, description="エンジン種別フィルタ (例: mysql)"),
+    region: Optional[str] = Query(default=None, description="リージョンフィルタ"),
+) -> InstanceListResponse:
+    """
+    登録済み RDS インスタンスの一覧を返す。
+
+    `?engine=mysql` や `?region=ap-northeast-1` で絞り込み可能。
+    """
+    instances = list(_instance_store.values())
+    if engine:
+        instances = [i for i in instances if i.engine.value == engine]
+    if region:
+        instances = [i for i in instances if i.region == region]
+
+    items = [
+        InstanceListItem(
+            instance_id=i.instance_id,
+            engine=i.engine.value,
+            engine_version=i.engine_version,
+            instance_class=i.instance_class,
+            region=i.region,
+            multi_az=i.multi_az,
+            storage_type=i.storage_type.value,
+            allocated_storage_gb=i.allocated_storage_gb,
+            has_metrics=i.instance_id in _metrics_store,
+            tags=i.tags,
+        )
+        for i in instances
+    ]
+    return InstanceListResponse(total=len(items), instances=items)
+
+

--- a/rds_analyzer/api/schemas.py
+++ b/rds_analyzer/api/schemas.py
@@ -310,3 +310,27 @@ class InstanceCostDiff(BaseModel):
     instance_class_b: str
     engine_a: str
     engine_b: str
+
+
+
+
+class InstanceListItem(BaseModel):
+    """GET /rds の1エントリ（軽量な一覧用）"""
+    instance_id: str
+    engine: str
+    engine_version: str
+    instance_class: str
+    region: str
+    multi_az: bool
+    storage_type: str
+    allocated_storage_gb: int
+    has_metrics: bool = Field(description="メトリクスが投入済みか")
+    tags: dict[str, str] = Field(default_factory=dict)
+
+
+class InstanceListResponse(BaseModel):
+    """GET /rds レスポンス"""
+    total: int
+    instances: list[InstanceListItem]
+
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,79 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+class TestInstanceList:
+    """GET /rds インスタンス一覧のテスト"""
+
+    @pytest.fixture(autouse=True)
+    def clear_stores(self):
+        from rds_analyzer.api import routes as _r
+        _r._instance_store.clear()
+        _r._metrics_store.clear()
+
+    def test_list_empty(self, client):
+        resp = client.get("/api/v1/rds")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 0
+        assert data["instances"] == []
+
+    def test_list_after_register(self, client, sample_instance_payload):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        resp = client.get("/api/v1/rds")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] >= 1
+        ids = [i["instance_id"] for i in data["instances"]]
+        assert "test-api-mysql-001" in ids
+
+    def test_list_has_metrics_flag(self, client, sample_instance_payload, sample_metrics_payload):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        resp_before = client.get("/api/v1/rds")
+        item_before = next(
+            i for i in resp_before.json()["instances"]
+            if i["instance_id"] == "test-api-mysql-001"
+        )
+        assert item_before["has_metrics"] is False
+
+        client.post("/api/v1/rds/test-api-mysql-001/metrics", json=sample_metrics_payload)
+        resp_after = client.get("/api/v1/rds")
+        item_after = next(
+            i for i in resp_after.json()["instances"]
+            if i["instance_id"] == "test-api-mysql-001"
+        )
+        assert item_after["has_metrics"] is True
+
+    def test_filter_by_engine(self, client, sample_instance_payload):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        resp = client.get("/api/v1/rds?engine=mysql")
+        assert resp.status_code == 200
+        for item in resp.json()["instances"]:
+            assert item["engine"] == "mysql"
+
+    def test_filter_by_engine_no_match(self, client, sample_instance_payload):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        resp = client.get("/api/v1/rds?engine=postgresql")
+        assert resp.status_code == 200
+        # mysql インスタンスしか登録していないので 0 件
+        assert resp.json()["total"] == 0
+
+    def test_filter_by_region(self, client, sample_instance_payload):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        resp = client.get("/api/v1/rds?region=ap-northeast-1")
+        assert resp.status_code == 200
+        assert resp.json()["total"] >= 1
+
+    def test_list_includes_tags(self, client, sample_instance_payload):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        resp = client.get("/api/v1/rds")
+        item = next(
+            i for i in resp.json()["instances"]
+            if i["instance_id"] == "test-api-mysql-001"
+        )
+        assert item["tags"].get("Environment") == "test"
+
+


### PR DESCRIPTION
## 概要

`GET /rds` エンドポイントを追加し、登録済みインスタンスの一覧を返します。エンジン種別・リージョンによるフィルタリングも対応します。

## 変更内容

### `rds_analyzer/api/schemas.py`
- `InstanceListItem` — 一覧用の軽量スキーマ（`has_metrics` フラグ付き）
- `InstanceListResponse` — `total` + `instances` リスト

### `rds_analyzer/api/routes.py`
- `GET /rds` エンドポイントを追加
  - `?engine=mysql` でエンジン種別フィルタ
  - `?region=ap-northeast-1` でリージョンフィルタ
  - `has_metrics` でメトリクス投入済みかを返す

### `tests/test_api.py`
- `TestInstanceList` クラスを追加（7 テスト）
  - 空一覧 → `total=0`
  - 登録後に一覧に含まれる
  - `has_metrics` フラグが投入前後で変化する
  - engine/region フィルタ動作
  - タグが一覧に含まれる


---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_