### PR TITLE
feat: PATCH /rds/{id} インスタンス設定部分更新エンドポイント追加

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -35,6 +35,7 @@ from .schemas import (
     IndexAnalysisApiRequest,
     IndexAnalysisResponse,
     InstanceSummaryItem,
+    InstanceUpdateRequest,
     MetricsInputRequest,
     PerformanceSummaryResponse,
     QueryPatternRequest,
@@ -176,6 +177,36 @@ async def register_instance(request: RDSInstanceRequest) -> dict:
     logger.info("インスタンス登録: %s (%s)", instance.instance_id, instance.engine)
 
     return {"message": "登録しました", "instance_id": instance.instance_id}
+
+
+@router.patch(
+    "/rds/{instance_id}",
+    response_model=dict,
+    tags=["instances"],
+    summary="RDS インスタンス設定を部分更新",
+)
+async def update_instance(instance_id: str, body: InstanceUpdateRequest) -> dict:
+    """
+    指定したフィールドのみを更新する（PATCH セマンティクス）。
+
+    変更可能フィールド: instance_class, engine_version, multi_az, storage_type,
+    allocated_storage_gb, provisioned_iops, backup_retention_days,
+    read_replica_count, tags
+    """
+    instance = get_instance_or_404(instance_id)
+    update_fields = body.model_dump(exclude_none=True)
+
+    if "storage_type" in update_fields:
+        try:
+            update_fields["storage_type"] = StorageType(update_fields["storage_type"])
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+
+    updated = instance.model_copy(update=update_fields)
+    _instance_store[instance_id] = updated
+    logger.info("インスタンス更新: %s fields=%s", instance_id, list(update_fields.keys()))
+
+    return {"message": "更新しました", "instance_id": instance_id, "updated_fields": list(update_fields.keys())}
 
 
 @router.post(

--- a/rds_analyzer/api/schemas.py
+++ b/rds_analyzer/api/schemas.py
@@ -118,6 +118,19 @@ class InstanceSummaryItem(BaseModel):
     top_recommendation: Optional[str] = None
 
 
+class InstanceUpdateRequest(BaseModel):
+    """PATCH /rds/{id} — 部分更新リクエスト（指定したフィールドのみ更新）"""
+    instance_class: Optional[str] = Field(default=None, description="変更後のインスタンスクラス")
+    engine_version: Optional[str] = Field(default=None, description="変更後のエンジンバージョン")
+    multi_az: Optional[bool] = Field(default=None, description="Multi-AZ 設定")
+    storage_type: Optional[str] = Field(default=None, description="ストレージタイプ (gp2/gp3/io1)")
+    allocated_storage_gb: Optional[int] = Field(default=None, ge=20, description="ストレージサイズ (GB)")
+    provisioned_iops: Optional[int] = Field(default=None, ge=1000, description="プロビジョニング IOPS (io1/gp3)")
+    backup_retention_days: Optional[int] = Field(default=None, ge=0, le=35)
+    read_replica_count: Optional[int] = Field(default=None, ge=0, le=5)
+    tags: Optional[dict[str, str]] = Field(default=None, description="タグ（完全置換）")
+
+
 class AnalysisResponse(BaseModel):
     """
     GET /rds/{id}/analysis レスポンス

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -90,6 +90,58 @@ class TestInstanceRegistration:
         assert response.status_code == 422
 
 
+class TestInstanceUpdate:
+    """PATCH /rds/{id} 部分更新のテスト"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+
+    def test_patch_instance_class(self, client):
+        resp = client.patch(
+            "/api/v1/rds/test-api-mysql-001",
+            json={"instance_class": "db.m5.xlarge"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "instance_class" in data["updated_fields"]
+
+    def test_patch_multi_az(self, client):
+        resp = client.patch(
+            "/api/v1/rds/test-api-mysql-001",
+            json={"multi_az": True},
+        )
+        assert resp.status_code == 200
+        assert "multi_az" in resp.json()["updated_fields"]
+
+    def test_patch_tags(self, client):
+        resp = client.patch(
+            "/api/v1/rds/test-api-mysql-001",
+            json={"tags": {"env": "prod", "team": "db"}},
+        )
+        assert resp.status_code == 200
+        assert "tags" in resp.json()["updated_fields"]
+
+    def test_patch_invalid_storage_type_returns_422(self, client):
+        resp = client.patch(
+            "/api/v1/rds/test-api-mysql-001",
+            json={"storage_type": "nvme"},
+        )
+        assert resp.status_code == 422
+
+    def test_patch_nonexistent_instance(self, client):
+        resp = client.patch(
+            "/api/v1/rds/no-such-instance",
+            json={"instance_class": "db.m5.xlarge"},
+        )
+        assert resp.status_code == 404
+
+    def test_patch_empty_body_is_noop(self, client):
+        resp = client.patch("/api/v1/rds/test-api-mysql-001", json={})
+        assert resp.status_code == 200
+        assert resp.json()["updated_fields"] == []
+
+
 class TestMetricsSubmission:
     def test_submit_metrics_success(
         self, client, sample_instance_payload, sample_metrics_payload


### PR DESCRIPTION
## 概要

`PATCH /rds/{id}` エンドポイントを追加し、インスタンス設定を部分更新できるようにします。PUT とは異なり、省略したフィールドは既存値が保持されます。

## 変更内容

### `rds_analyzer/api/schemas.py`
- `InstanceUpdateRequest` — 全フィールドが `Optional`（省略で既存値を保持）
  - `instance_class`, `engine_version`, `multi_az`, `storage_type`
  - `allocated_storage_gb`, `provisioned_iops`, `backup_retention_days`
  - `read_replica_count`, `tags`

### `rds_analyzer/api/routes.py`
- `PATCH /rds/{instance_id}` を追加
  - `model_dump(exclude_none=True)` で指定フィールドのみ抽出
  - `model_copy(update=...)` でイミュータブルに更新
  - `storage_type` バリデーション → 不正値は 422
  - レスポンスに `updated_fields` リストを含む

### `tests/test_api.py`
- `TestInstanceUpdate` クラスを追加（6 テスト）
  - instance_class 更新
  - multi_az 更新
  - tags 更新
  - 不正 storage_type → 422
  - 存在しない ID → 404
  - 空ボディ → 200 (`updated_fields=[]`)


---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_