### PR TITLE
feat: GET /rds/{id}/cost コスト内訳専用エンドポイントを追加

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -557,6 +557,69 @@ def _build_status_summary(perf: PerformanceAnalysisResult) -> str:
 # 拡張エンドポイント（ML 異常検知 / コスト予測 / レポート / Slack）
 # ============================================================
 
+@router.get(
+    "/rds/{instance_id}/cost",
+    response_model=CostSummaryResponse,
+    tags=["analysis"],
+    summary="インスタンスのコスト内訳を取得",
+)
+async def get_instance_cost(
+    instance_id: str,
+    data_transfer_gb: float = Query(default=0.0, ge=0),
+    cost_analyzer: CostAnalyzer = Depends(get_cost_analyzer),
+) -> CostSummaryResponse:
+    """
+    特定インスタンスのコスト内訳のみを返す。
+
+    パフォーマンス分析が不要な場合に /analysis より軽量。
+    メトリクス登録不要で呼び出せる。
+    """
+    instance = get_instance_or_404(instance_id)
+    breakdown, _ = cost_analyzer.calculate_monthly_cost(
+        instance, data_transfer_gb=data_transfer_gb
+    )
+
+    from datetime import date
+    current_month = date.today().strftime("%Y-%m")
+
+    metrics = _metrics_store.get(instance_id)
+    if metrics:
+        storage_used_gb = (
+            instance.allocated_storage_gb
+            - metrics.free_storage_bytes.avg / (1024 ** 3)
+        )
+        eff_score = cost_analyzer.calculate_efficiency_score(
+            instance=instance,
+            breakdown=breakdown,
+            avg_cpu_pct=metrics.cpu_utilization.avg,
+            avg_iops_used=metrics.avg_total_iops,
+            storage_used_gb=storage_used_gb,
+        )
+        score = eff_score.score
+        grade = eff_score.grade
+    else:
+        score = 75
+        grade = "B"
+
+    return CostSummaryResponse(
+        instance_id=instance_id,
+        month=current_month,
+        total_cost_usd=round(breakdown.total_cost_usd, 2),
+        breakdown={
+            "compute": round(breakdown.compute_cost_usd + breakdown.replica_compute_cost_usd, 2),
+            "storage": round(breakdown.storage_cost_usd, 2),
+            "iops": round(breakdown.iops_cost_usd, 2),
+            "transfer": round(breakdown.transfer_cost_usd, 2),
+            "backup": round(breakdown.backup_cost_usd, 2),
+        },
+        cost_efficiency_score=score,
+        grade=grade,
+        potential_savings_usd=round(
+            cost_analyzer.estimate_gp3_savings(instance), 2
+        ),
+    )
+
+
 @router.post(
     "/rds/{instance_id}/cost-history",
     response_model=dict,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -185,6 +185,55 @@ class TestSummary:
         assert data["total_monthly_cost_usd"] > 0
 
 
+class TestInstanceCostDetail:
+    """GET /rds/{id}/cost エンドポイントのテスト"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post(
+            "/api/v1/rds/test-api-mysql-001/metrics",
+            json=sample_metrics_payload,
+        )
+
+    def test_cost_detail_success(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/cost")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["instance_id"] == "test-api-mysql-001"
+        assert "total_cost_usd" in data
+        assert data["total_cost_usd"] > 0
+
+    def test_cost_detail_breakdown_keys(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/cost")
+        breakdown = resp.json()["breakdown"]
+        for key in ("compute", "storage", "iops", "transfer", "backup"):
+            assert key in breakdown
+
+    def test_cost_detail_has_grade(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/cost")
+        data = resp.json()
+        assert "grade" in data
+        assert data["grade"] in ("A", "B", "C", "D", "F")
+
+    def test_cost_detail_without_metrics(self, client, sample_instance_payload):
+        payload = {**sample_instance_payload, "instance_id": "no-metrics-inst"}
+        client.post("/api/v1/rds", json=payload)
+        resp = client.get("/api/v1/rds/no-metrics-inst/cost")
+        assert resp.status_code == 200
+        assert resp.json()["cost_efficiency_score"] == 75
+
+    def test_cost_detail_not_found(self, client):
+        resp = client.get("/api/v1/rds/no-such-instance/cost")
+        assert resp.status_code == 404
+
+    def test_cost_detail_has_potential_savings(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/cost")
+        data = resp.json()
+        assert "potential_savings_usd" in data
+        assert data["potential_savings_usd"] >= 0
+
+
 class TestCostHistory:
     @pytest.fixture(autouse=True)
     def setup(self, client, sample_instance_payload):


### PR DESCRIPTION
## 概要

`GET /rds/{id}/cost` エンドポイントを追加し、コスト内訳のみを軽量に取得できるようにしました。

## 変更内容

- `GET /rds/{id}/analysis` と異なりメトリクス登録不要で呼び出し可能
- メトリクスがある場合は実測値でコスト効率スコア/グレードを計算
- ない場合はデフォルトスコア 75 / グレード B を返す
- レスポンスは `CostSummaryResponse`（既存スキーマを再利用）

## テスト

```
pytest tests/test_api.py::TestInstanceCostDetail -v
# 6 passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_