### PR TITLE
feat: GET /rds/{id}/performance パフォーマンスサマリー専用エンドポイントを追加

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -557,6 +557,39 @@ def _build_status_summary(perf: PerformanceAnalysisResult) -> str:
 # 拡張エンドポイント（ML 異常検知 / コスト予測 / レポート / Slack）
 # ============================================================
 
+@router.get(
+    "/rds/{instance_id}/performance",
+    response_model=PerformanceSummaryResponse,
+    tags=["analysis"],
+    summary="インスタンスのパフォーマンスサマリーを取得",
+)
+async def get_instance_performance(
+    instance_id: str,
+    perf_analyzer: PerformanceAnalyzer = Depends(get_performance_analyzer),
+) -> PerformanceSummaryResponse:
+    """
+    特定インスタンスのパフォーマンスサマリーのみを返す。
+
+    コスト分析が不要な場合に /analysis より軽量。
+    メトリクスの事前登録が必要。
+    """
+    instance = get_instance_or_404(instance_id)
+    metrics = get_metrics_or_404(instance_id)
+
+    perf_result = perf_analyzer.analyze(instance, metrics)
+
+    return PerformanceSummaryResponse(
+        instance_id=instance_id,
+        health_score=perf_result.health_score,
+        status_summary=_build_status_summary(perf_result),
+        bottlenecks=perf_result.critical_issues,
+        cpu_avg_pct=round(perf_result.cpu_avg_pct, 1),
+        memory_free_gb=round(perf_result.freeable_memory_avg_gb, 2),
+        avg_total_iops=round(perf_result.avg_total_iops, 0),
+        avg_connections=round(perf_result.avg_connections, 0),
+    )
+
+
 @router.post(
     "/rds/{instance_id}/cost-history",
     response_model=dict,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -185,6 +185,53 @@ class TestSummary:
         assert data["total_monthly_cost_usd"] > 0
 
 
+class TestInstancePerformance:
+    """GET /rds/{id}/performance エンドポイントのテスト"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post(
+            "/api/v1/rds/test-api-mysql-001/metrics",
+            json=sample_metrics_payload,
+        )
+
+    def test_performance_success(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/performance")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["instance_id"] == "test-api-mysql-001"
+        assert "health_score" in data
+
+    def test_performance_health_score_range(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/performance")
+        data = resp.json()
+        assert 0 <= data["health_score"] <= 100
+
+    def test_performance_has_status_summary(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/performance")
+        data = resp.json()
+        assert "status_summary" in data
+        assert len(data["status_summary"]) > 0
+
+    def test_performance_has_cpu_and_memory(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/performance")
+        data = resp.json()
+        assert "cpu_avg_pct" in data
+        assert "memory_free_gb" in data
+        assert data["cpu_avg_pct"] >= 0
+
+    def test_performance_not_found_instance(self, client):
+        resp = client.get("/api/v1/rds/no-such-inst/performance")
+        assert resp.status_code == 404
+
+    def test_performance_no_metrics_returns_404(self, client, sample_instance_payload):
+        payload = {**sample_instance_payload, "instance_id": "no-metrics-perf"}
+        client.post("/api/v1/rds", json=payload)
+        resp = client.get("/api/v1/rds/no-metrics-perf/performance")
+        assert resp.status_code == 404
+
+
 class TestCostHistory:
     @pytest.fixture(autouse=True)
     def setup(self, client, sample_instance_payload):


### PR DESCRIPTION
## 概要

`GET /rds/{id}/performance` エンドポイントを追加し、パフォーマンスサマリーのみを軽量取得できるようにしました。

## 変更内容

- コスト計算をスキップするため `/analysis` より高速
- `health_score`, `status_summary`, `cpu_avg_pct`, `memory_free_gb`, `avg_total_iops`, `avg_connections`, `bottlenecks` を返す
- メトリクス未登録時は 404 を返す
- `PerformanceSummaryResponse` スキーマを再利用

## テスト

```
pytest tests/test_api.py::TestInstancePerformance -v
# 6 passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_