### PR TITLE
feat: POST /rds/{id}/clone インスタンス設定コピーエンドポイントを追加

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -558,6 +558,55 @@ def _build_status_summary(perf: PerformanceAnalysisResult) -> str:
 # ============================================================
 
 @router.post(
+    "/rds/{instance_id}/clone",
+    response_model=dict,
+    status_code=status.HTTP_201_CREATED,
+    tags=["instances"],
+    summary="インスタンス設定をコピーして新規インスタンスを登録",
+)
+async def clone_instance(
+    instance_id: str,
+    new_instance_id: str = Query(description="新しいインスタンスID"),
+) -> dict:
+    """
+    既存インスタンスの設定をコピーして新規インスタンスを登録する。
+
+    - 新インスタンスIDが既存と重複する場合は 409
+    - メトリクスはコピーされない
+    """
+    source = get_instance_or_404(instance_id)
+    if new_instance_id in _instance_store:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"インスタンス '{new_instance_id}' は既に存在します",
+        )
+
+    cloned = RDSInstance(
+        instance_id=new_instance_id,
+        engine=source.engine,
+        engine_version=source.engine_version,
+        instance_class=source.instance_class,
+        region=source.region,
+        multi_az=source.multi_az,
+        storage_type=source.storage_type,
+        allocated_storage_gb=source.allocated_storage_gb,
+        provisioned_iops=source.provisioned_iops,
+        read_replica_count=source.read_replica_count,
+        backup_retention_days=source.backup_retention_days,
+        snapshot_storage_gb=source.snapshot_storage_gb,
+        tags=dict(source.tags),
+    )
+    _instance_store[new_instance_id] = cloned
+    logger.info("インスタンスをクローン: %s -> %s", instance_id, new_instance_id)
+
+    return {
+        "message": "クローンしました",
+        "source_instance_id": instance_id,
+        "new_instance_id": new_instance_id,
+    }
+
+
+@router.post(
     "/rds/{instance_id}/cost-history",
     response_model=dict,
     tags=["analysis"],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -185,6 +185,53 @@ class TestSummary:
         assert data["total_monthly_cost_usd"] > 0
 
 
+class TestInstanceClone:
+    """POST /rds/{id}/clone エンドポイントのテスト"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        from rds_analyzer.api import routes as _routes
+        _routes._instance_store.clear()
+        client.post("/api/v1/rds", json=sample_instance_payload)
+
+    def test_clone_success(self, client):
+        resp = client.post(
+            "/api/v1/rds/test-api-mysql-001/clone?new_instance_id=cloned-001"
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["new_instance_id"] == "cloned-001"
+        assert data["source_instance_id"] == "test-api-mysql-001"
+
+    def test_clone_registers_new_instance(self, client):
+        client.post("/api/v1/rds/test-api-mysql-001/clone?new_instance_id=cloned-reg")
+        resp = client.get("/api/v1/rds/summary")
+        ids = [i["instance_id"] for i in resp.json()["instances"]]
+        assert "cloned-reg" in ids
+
+    def test_clone_conflict_returns_409(self, client, sample_instance_payload):
+        payload = {**sample_instance_payload, "instance_id": "already-exists"}
+        client.post("/api/v1/rds", json=payload)
+        resp = client.post(
+            "/api/v1/rds/test-api-mysql-001/clone?new_instance_id=already-exists"
+        )
+        assert resp.status_code == 409
+
+    def test_clone_source_not_found(self, client):
+        resp = client.post(
+            "/api/v1/rds/no-such-inst/clone?new_instance_id=cloned-x"
+        )
+        assert resp.status_code == 404
+
+    def test_clone_preserves_engine(self, client):
+        client.post("/api/v1/rds/test-api-mysql-001/clone?new_instance_id=cloned-eng")
+        resp = client.get("/api/v1/rds/summary")
+        cloned = next(
+            i for i in resp.json()["instances"] if i["instance_id"] == "cloned-eng"
+        )
+        assert cloned["engine"] == "mysql"
+
+
 class TestCostHistory:
     @pytest.fixture(autouse=True)
     def setup(self, client, sample_instance_payload):


### PR DESCRIPTION
## 概要

`POST /rds/{id}/clone?new_instance_id=xxx` エンドポイントを追加し、既存インスタンスの設定を複製して新規インスタンスとして登録できるようにしました。

## 変更内容

- `?new_instance_id=` クエリパラメータで複製先 ID を指定
- 重複 ID の場合は 409 Conflict を返す
- ソースインスタンスが存在しない場合は 404
- メトリクス・コスト履歴はコピーされない
- 201 Created でレスポンス

## テスト

```
pytest tests/test_api.py::TestInstanceClone -v
# 5 passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_