### PR TITLE
feat: GET /rds/{id}/recommendations に ?min_savings= フィルタを追加

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -483,6 +483,7 @@ async def get_recommendations(
     data_transfer_gb: float = Query(default=0.0, ge=0),
     limit: int = Query(default=20, ge=1, le=100, description="1ページあたりの件数"),
     offset: int = Query(default=0, ge=0, description="スキップする件数"),
+    min_savings: float = Query(default=0.0, ge=0, description="最低推定節約額フィルタ (USD/月)"),
     cost_analyzer: CostAnalyzer = Depends(get_cost_analyzer),
     perf_analyzer: PerformanceAnalyzer = Depends(get_performance_analyzer),
     rec_engine: RecommendationEngine = Depends(get_recommendation_engine),
@@ -502,10 +503,6 @@ async def get_recommendations(
     perf_result = perf_analyzer.analyze(instance, metrics)
     recommendations = rec_engine.generate_recommendations(instance, perf_result, breakdown)
 
-    total_savings = sum(
-        max(0, r.estimated_monthly_savings_usd) for r in recommendations
-    )
-
     rec_items = [
         RecommendationItem(
             id=r.recommendation_id,
@@ -524,11 +521,16 @@ async def get_recommendations(
         for r in recommendations
     ]
 
+    # min_savings フィルタを適用
+    if min_savings > 0:
+        rec_items = [r for r in rec_items if r.estimated_monthly_savings_usd >= min_savings]
+
+    total_savings = sum(max(0, r.estimated_monthly_savings_usd) for r in rec_items)
     paginated_items = rec_items[offset: offset + limit]
     return RecommendationResponse(
         instance_id=instance_id,
         generated_at=datetime.utcnow(),
-        total_recommendations=len(recommendations),
+        total_recommendations=len(rec_items),
         total_potential_savings_usd=round(total_savings, 2),
         recommendations=paginated_items,
         limit=limit,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -185,6 +185,50 @@ class TestSummary:
         assert data["total_monthly_cost_usd"] > 0
 
 
+class TestRecommendationMinSavingsFilter:
+    """GET /rds/{id}/recommendations?min_savings= フィルタのテスト"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post(
+            "/api/v1/rds/test-api-mysql-001/metrics",
+            json=sample_metrics_payload,
+        )
+
+    def test_no_filter_returns_all(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/recommendations")
+        assert resp.status_code == 200
+        assert isinstance(resp.json()["recommendations"], list)
+
+    def test_zero_min_savings_returns_all(self, client):
+        all_resp = client.get("/api/v1/rds/test-api-mysql-001/recommendations")
+        filtered_resp = client.get(
+            "/api/v1/rds/test-api-mysql-001/recommendations?min_savings=0"
+        )
+        assert all_resp.json()["total_recommendations"] == filtered_resp.json()["total_recommendations"]
+
+    def test_high_min_savings_reduces_count(self, client):
+        resp = client.get(
+            "/api/v1/rds/test-api-mysql-001/recommendations?min_savings=99999"
+        )
+        assert resp.status_code == 200
+        assert resp.json()["total_recommendations"] == 0
+
+    def test_filtered_recs_meet_threshold(self, client):
+        resp = client.get(
+            "/api/v1/rds/test-api-mysql-001/recommendations?min_savings=1.0"
+        )
+        for rec in resp.json()["recommendations"]:
+            assert rec["estimated_monthly_savings_usd"] >= 1.0
+
+    def test_not_found_returns_404(self, client):
+        resp = client.get(
+            "/api/v1/rds/no-such/recommendations?min_savings=10"
+        )
+        assert resp.status_code == 404
+
+
 class TestCostHistory:
     @pytest.fixture(autouse=True)
     def setup(self, client, sample_instance_payload):


### PR DESCRIPTION
## 概要

`GET /rds/{id}/recommendations` に `?min_savings=` クエリパラメータを追加し、推定節約額の下限でフィルタリングできるようにしました。

## 変更内容

- `min_savings` (USD/月) 以上の節約が見込まれるレコメンドのみを返す
- デフォルト 0.0（フィルタなし）
- フィルタ後の件数と合計節約額が `total_recommendations`・`total_potential_savings_usd` に反映される

## テスト

```
pytest tests/test_api.py::TestRecommendationMinSavingsFilter -v
# 5 passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_