### PR TITLE
feat: GET /rds/{id}/cost-history/stats コスト履歴統計サマリーエンドポイントを追加

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -579,6 +579,48 @@ async def add_cost_history(
 
 
 @router.get(
+    "/rds/{instance_id}/cost-history/stats",
+    response_model=dict,
+    tags=["analysis"],
+    summary="月次コスト履歴の統計サマリーを取得",
+)
+async def get_cost_history_stats(instance_id: str) -> dict:
+    """
+    登録済み月次コスト履歴の統計サマリーを返す。
+
+    - 平均・最大・最小・合計コスト
+    - 最初/最後の月
+    - 先に POST /rds/{id}/cost-history でデータを登録してください
+    """
+    get_instance_or_404(instance_id)
+    history = _cost_history_store.get(instance_id, [])
+    if not history:
+        return {
+            "instance_id": instance_id,
+            "total_months": 0,
+            "avg_cost_usd": None,
+            "max_cost_usd": None,
+            "min_cost_usd": None,
+            "total_cost_usd": None,
+            "first_month": None,
+            "last_month": None,
+        }
+
+    costs = [c for _, c in history]
+    months = [m for m, _ in history]
+    return {
+        "instance_id": instance_id,
+        "total_months": len(history),
+        "avg_cost_usd": round(sum(costs) / len(costs), 2),
+        "max_cost_usd": round(max(costs), 2),
+        "min_cost_usd": round(min(costs), 2),
+        "total_cost_usd": round(sum(costs), 2),
+        "first_month": min(months),
+        "last_month": max(months),
+    }
+
+
+@router.get(
     "/rds/{instance_id}/forecast",
     response_model=dict,
     tags=["analysis"],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -208,6 +208,60 @@ class TestCostHistory:
         assert resp.status_code == 404
 
 
+class TestCostHistoryStats:
+    """GET /rds/{id}/cost-history/stats エンドポイントのテスト"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        from rds_analyzer.api import routes as _routes
+        _routes._cost_history_store.clear()
+        client.post("/api/v1/rds", json=sample_instance_payload)
+
+    def test_stats_with_history(self, client):
+        history = [
+            {"month": f"2024-{i:02d}", "cost_usd": float(400 + i * 10)}
+            for i in range(1, 7)
+        ]
+        client.post("/api/v1/rds/test-api-mysql-001/cost-history", json=history)
+        resp = client.get("/api/v1/rds/test-api-mysql-001/cost-history/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_months"] == 6
+        assert data["min_cost_usd"] == 410.0
+        assert data["max_cost_usd"] == 460.0
+
+    def test_stats_no_history_returns_nulls(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/cost-history/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_months"] == 0
+        assert data["avg_cost_usd"] is None
+
+    def test_stats_has_first_and_last_month(self, client):
+        history = [
+            {"month": "2024-01", "cost_usd": 400.0},
+            {"month": "2024-06", "cost_usd": 500.0},
+        ]
+        client.post("/api/v1/rds/test-api-mysql-001/cost-history", json=history)
+        resp = client.get("/api/v1/rds/test-api-mysql-001/cost-history/stats")
+        data = resp.json()
+        assert data["first_month"] == "2024-01"
+        assert data["last_month"] == "2024-06"
+
+    def test_stats_not_found(self, client):
+        resp = client.get("/api/v1/rds/no-such/cost-history/stats")
+        assert resp.status_code == 404
+
+    def test_stats_total_cost_is_sum(self, client):
+        history = [
+            {"month": "2024-01", "cost_usd": 100.0},
+            {"month": "2024-02", "cost_usd": 200.0},
+        ]
+        client.post("/api/v1/rds/test-api-mysql-001/cost-history", json=history)
+        resp = client.get("/api/v1/rds/test-api-mysql-001/cost-history/stats")
+        assert resp.json()["total_cost_usd"] == 300.0
+
+
 class TestForecast:
     @pytest.fixture(autouse=True)
     def setup(self, client, sample_instance_payload):


### PR DESCRIPTION
## 概要

`GET /rds/{id}/cost-history/stats` エンドポイントを追加し、登録済み月次コスト履歴の統計サマリーを取得できるようにしました。

## 変更内容

- 平均・最大・最小・合計コスト（USD）を返す
- 最初の月 / 最後の月（YYYY-MM）を返す
- 履歴未登録の場合は `total_months: 0` + 各統計値 `null` で 200 を返す
- 先に `POST /rds/{id}/cost-history` でデータ登録が必要

## テスト

```
pytest tests/test_api.py::TestCostHistoryStats -v
# 5 passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_