### PR TITLE
feat: GET /rds/count インスタンス件数エンドポイントを追加

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -294,6 +294,30 @@ async def submit_metrics(
 
 
 @router.get(
+    "/rds/count",
+    response_model=dict,
+    tags=["instances"],
+    summary="登録インスタンス数を取得",
+)
+async def get_instance_count() -> dict:
+    """
+    登録済みインスタンスの件数と内訳を返す。
+
+    /rds/summary よりも軽量（コスト計算なし）。
+    """
+    with_metrics = sum(1 for iid in _instance_store if iid in _metrics_store)
+    engines: dict[str, int] = {}
+    for inst in _instance_store.values():
+        engines[inst.engine.value] = engines.get(inst.engine.value, 0) + 1
+    return {
+        "total": len(_instance_store),
+        "with_metrics": with_metrics,
+        "without_metrics": len(_instance_store) - with_metrics,
+        "by_engine": engines,
+    }
+
+
+@router.get(
     "/rds/summary",
     response_model=RDSSummaryResponse,
     tags=["analysis"],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -185,6 +185,51 @@ class TestSummary:
         assert data["total_monthly_cost_usd"] > 0
 
 
+class TestInstanceCount:
+    """GET /rds/count エンドポイントのテスト"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, client):
+        from rds_analyzer.api import routes as _routes
+        _routes._instance_store.clear()
+        _routes._metrics_store.clear()
+
+    def test_count_empty(self, client):
+        resp = client.get("/api/v1/rds/count")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    def test_count_with_instance(self, client, sample_instance_payload):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        resp = client.get("/api/v1/rds/count")
+        assert resp.json()["total"] == 1
+
+    def test_count_with_and_without_metrics(
+        self, client, sample_instance_payload, sample_metrics_payload
+    ):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post(
+            "/api/v1/rds/test-api-mysql-001/metrics", json=sample_metrics_payload
+        )
+        resp = client.get("/api/v1/rds/count")
+        data = resp.json()
+        assert data["with_metrics"] == 1
+        assert data["without_metrics"] == 0
+
+    def test_count_by_engine(self, client, sample_instance_payload):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        resp = client.get("/api/v1/rds/count")
+        data = resp.json()
+        assert "by_engine" in data
+        assert data["by_engine"].get("mysql", 0) >= 1
+
+    def test_count_response_has_required_keys(self, client):
+        resp = client.get("/api/v1/rds/count")
+        data = resp.json()
+        for key in ("total", "with_metrics", "without_metrics", "by_engine"):
+            assert key in data
+
+
 class TestCostHistory:
     @pytest.fixture(autouse=True)
     def setup(self, client, sample_instance_payload):


### PR DESCRIPTION
## 概要

`GET /rds/count` エンドポイントを追加し、登録インスタンスの件数を軽量に取得できるようにしました。

## 変更内容

- 合計件数・メトリクスあり/なし件数・エンジン別件数を返す
- コスト計算を行わないため `/rds/summary` よりも高速
- `/rds/summary` は依然として詳細なコスト情報も含む

## テスト

```
pytest tests/test_api.py::TestInstanceCount -v
# 5 passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_