### PR TITLE
feat: GET /rds/{id}/warnings インスタンス設定警告エンドポイントを追加

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -557,6 +557,68 @@ def _build_status_summary(perf: PerformanceAnalysisResult) -> str:
 # 拡張エンドポイント（ML 異常検知 / コスト予測 / レポート / Slack）
 # ============================================================
 
+@router.get(
+    "/rds/{instance_id}/warnings",
+    response_model=dict,
+    tags=["analysis"],
+    summary="インスタンスの設定警告一覧を取得",
+)
+async def get_instance_warnings(
+    instance_id: str,
+    perf_analyzer: PerformanceAnalyzer = Depends(get_performance_analyzer),
+) -> dict:
+    """
+    インスタンス設定に対する警告（注意事項）一覧を返す。
+
+    メトリクスがある場合はストレージ使用率も確認。
+    全警告 + 重要度を返す。
+    """
+    instance = get_instance_or_404(instance_id)
+    warnings: list[dict] = []
+
+    if not instance.multi_az:
+        warnings.append({
+            "level": "warning",
+            "code": "NO_MULTI_AZ",
+            "message": "シングルAZ構成です。本番環境ではマルチAZを推奨します",
+        })
+
+    if instance.backup_retention_days == 0:
+        warnings.append({
+            "level": "critical",
+            "code": "NO_BACKUP",
+            "message": "自動バックアップが無効です",
+        })
+    elif instance.backup_retention_days < 3:
+        warnings.append({
+            "level": "warning",
+            "code": "SHORT_BACKUP_RETENTION",
+            "message": f"バックアップ保持期間が {instance.backup_retention_days} 日と短いです（推奨: 7 日以上）",
+        })
+
+    metrics = _metrics_store.get(instance_id)
+    if metrics:
+        perf = perf_analyzer.analyze(instance, metrics)
+        if perf.storage_utilization_pct >= 80:
+            warnings.append({
+                "level": "critical",
+                "code": "HIGH_STORAGE_USAGE",
+                "message": f"ストレージ使用率が {perf.storage_utilization_pct:.0f}% に達しています",
+            })
+        if perf.cpu_avg_pct >= 80:
+            warnings.append({
+                "level": "warning",
+                "code": "HIGH_CPU",
+                "message": f"平均CPU使用率が {perf.cpu_avg_pct:.1f}% と高い状態です",
+            })
+
+    return {
+        "instance_id": instance_id,
+        "total_warnings": len(warnings),
+        "warnings": warnings,
+    }
+
+
 @router.post(
     "/rds/{instance_id}/cost-history",
     response_model=dict,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -185,6 +185,48 @@ class TestSummary:
         assert data["total_monthly_cost_usd"] > 0
 
 
+class TestAnalysisWarnings:
+    """GET /rds/{id}/warnings エンドポイントのテスト"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post(
+            "/api/v1/rds/test-api-mysql-001/metrics",
+            json=sample_metrics_payload,
+        )
+
+    def test_warnings_success(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/warnings")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "warnings" in data
+        assert isinstance(data["warnings"], list)
+
+    def test_single_az_produces_warning(self, client, sample_instance_payload):
+        payload = {**sample_instance_payload, "instance_id": "single-az-inst", "multi_az": False}
+        client.post("/api/v1/rds", json=payload)
+        resp = client.get("/api/v1/rds/single-az-inst/warnings")
+        codes = [w["code"] for w in resp.json()["warnings"]]
+        assert "NO_MULTI_AZ" in codes
+
+    def test_total_warnings_matches_list_length(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/warnings")
+        data = resp.json()
+        assert data["total_warnings"] == len(data["warnings"])
+
+    def test_warnings_has_level_and_message(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/warnings")
+        for w in resp.json()["warnings"]:
+            assert "level" in w
+            assert "message" in w
+            assert w["level"] in ("critical", "warning", "info")
+
+    def test_warnings_not_found(self, client):
+        resp = client.get("/api/v1/rds/no-such-instance/warnings")
+        assert resp.status_code == 404
+
+
 class TestCostHistory:
     @pytest.fixture(autouse=True)
     def setup(self, client, sample_instance_payload):


### PR DESCRIPTION
## 概要

`GET /rds/{id}/warnings` エンドポイントを追加し、インスタンス設定上の警告一覧を専用APIで取得できるようにしました。

## 変更内容

検出する警告:
- `NO_MULTI_AZ`: シングルAZ構成（level: warning）
- `NO_BACKUP`: 自動バックアップ無効（level: critical）
- `SHORT_BACKUP_RETENTION`: バックアップ保持期間 < 3日（level: warning）
- `HIGH_STORAGE_USAGE`: ストレージ使用率 ≥ 80%（level: critical、メトリクス要）
- `HIGH_CPU`: CPU平均 ≥ 80%（level: warning、メトリクス要）

各警告は `level`, `code`, `message` を持つ。

## テスト

```
pytest tests/test_api.py::TestAnalysisWarnings -v
# 5 passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_