### PR TITLE
feat: GET /rds/{id}/recommendations に ?sort= ソートパラメータを追加

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -483,6 +483,7 @@ async def get_recommendations(
     data_transfer_gb: float = Query(default=0.0, ge=0),
     limit: int = Query(default=20, ge=1, le=100, description="1ページあたりの件数"),
     offset: int = Query(default=0, ge=0, description="スキップする件数"),
+    sort: Optional[str] = Query(default=None, description="ソートキー: savings (推定節約額降順) / complexity (複雑度昇順) / priority (デフォルト)"),
     cost_analyzer: CostAnalyzer = Depends(get_cost_analyzer),
     perf_analyzer: PerformanceAnalyzer = Depends(get_performance_analyzer),
     rec_engine: RecommendationEngine = Depends(get_recommendation_engine),
@@ -501,6 +502,14 @@ async def get_recommendations(
     )
     perf_result = perf_analyzer.analyze(instance, metrics)
     recommendations = rec_engine.generate_recommendations(instance, perf_result, breakdown)
+
+    # sort バリデーション
+    allowed_sorts = {"savings", "complexity", "priority"}
+    if sort and sort not in allowed_sorts:
+        raise HTTPException(
+            status_code=422,
+            detail=f"無効な sort 値: '{sort}'。有効値: {', '.join(sorted(allowed_sorts))}",
+        )
 
     total_savings = sum(
         max(0, r.estimated_monthly_savings_usd) for r in recommendations
@@ -523,6 +532,12 @@ async def get_recommendations(
         )
         for r in recommendations
     ]
+
+    # ソート適用
+    if sort == "savings":
+        rec_items = sorted(rec_items, key=lambda r: r.estimated_monthly_savings_usd, reverse=True)
+    elif sort == "complexity":
+        rec_items = sorted(rec_items, key=lambda r: r.implementation_complexity)
 
     paginated_items = rec_items[offset: offset + limit]
     return RecommendationResponse(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -185,6 +185,52 @@ class TestSummary:
         assert data["total_monthly_cost_usd"] > 0
 
 
+class TestRecommendationsSort:
+    """GET /rds/{id}/recommendations?sort= ソートのテスト"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post(
+            "/api/v1/rds/test-api-mysql-001/metrics",
+            json=sample_metrics_payload,
+        )
+
+    def test_sort_by_savings(self, client):
+        resp = client.get(
+            "/api/v1/rds/test-api-mysql-001/recommendations?sort=savings"
+        )
+        assert resp.status_code == 200
+        recs = resp.json()["recommendations"]
+        savings = [r["estimated_monthly_savings_usd"] for r in recs]
+        assert savings == sorted(savings, reverse=True)
+
+    def test_sort_by_complexity(self, client):
+        resp = client.get(
+            "/api/v1/rds/test-api-mysql-001/recommendations?sort=complexity"
+        )
+        assert resp.status_code == 200
+        recs = resp.json()["recommendations"]
+        complexities = [r["implementation_complexity"] for r in recs]
+        assert complexities == sorted(complexities)
+
+    def test_sort_default_priority(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/recommendations")
+        assert resp.status_code == 200
+
+    def test_invalid_sort_returns_422(self, client):
+        resp = client.get(
+            "/api/v1/rds/test-api-mysql-001/recommendations?sort=invalid"
+        )
+        assert resp.status_code == 422
+
+    def test_sort_not_found_returns_404(self, client):
+        resp = client.get(
+            "/api/v1/rds/no-such/recommendations?sort=savings"
+        )
+        assert resp.status_code == 404
+
+
 class TestCostHistory:
     @pytest.fixture(autouse=True)
     def setup(self, client, sample_instance_payload):


### PR DESCRIPTION
## 概要

`GET /rds/{id}/recommendations` に `?sort=` クエリパラメータを追加し、レコメンドの並び順を指定できるようにしました。

## 変更内容

| sort値 | 動作 |
|--------|------|
| `priority` (デフォルト) | エンジン生成順（優先度順） |
| `savings` | 推定月次節約額の降順 |
| `complexity` | 実装複雑度の昇順 |

- 無効な sort 値は 422 を返す

## テスト

```
pytest tests/test_api.py::TestRecommendationsSort -v
# 5 passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_