### PR TITLE
feat: GET /rds/{id}/storage — ストレージ情報エンドポイント

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,45 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+@router.get(
+    "/rds/{instance_id}/storage",
+    response_model=dict,
+    tags=["analysis"],
+    summary="インスタンスのストレージ情報を取得",
+)
+async def get_instance_storage(instance_id: str) -> dict:
+    """
+    インスタンスのストレージ設定と使用状況を返す。
+
+    メトリクスがある場合は空き容量・使用率も含む。
+    """
+    instance = get_instance_or_404(instance_id)
+    from ..analyzers.cost_analyzer import STORAGE_RATES, IOPS_RATES
+
+    info: dict = {
+        "instance_id": instance_id,
+        "storage_type": instance.storage_type.value,
+        "allocated_storage_gb": instance.allocated_storage_gb,
+        "snapshot_storage_gb": instance.snapshot_storage_gb,
+        "provisioned_iops": instance.provisioned_iops,
+        "free_storage_gb": None,
+        "used_storage_gb": None,
+        "utilization_pct": None,
+    }
+
+    metrics = _metrics_store.get(instance_id)
+    if metrics:
+        free_gb = round(metrics.free_storage_bytes.avg / (1024 ** 3), 2)
+        used_gb = round(instance.allocated_storage_gb - free_gb, 2)
+        utilization = round(used_gb / instance.allocated_storage_gb * 100, 1)
+        info["free_storage_gb"] = free_gb
+        info["used_storage_gb"] = used_gb
+        info["utilization_pct"] = utilization
+
+    return info
+
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,49 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+
+
+class TestInstanceStorage:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        from rds_analyzer.api.routes import _instance_store, _metrics_store
+        _instance_store.clear()
+        _metrics_store.clear()
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post(
+            "/api/v1/rds/test-api-mysql-001/metrics",
+            json=sample_metrics_payload,
+        )
+
+    def test_storage_returns_200(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/storage")
+        assert resp.status_code == 200
+
+    def test_storage_contains_required_fields(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/storage").json()
+        assert data["instance_id"] == "test-api-mysql-001"
+        assert data["storage_type"] == "gp2"
+        assert data["allocated_storage_gb"] == 100
+
+    def test_storage_includes_utilization_when_metrics_exist(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/storage").json()
+        assert data["free_storage_gb"] is not None
+        assert data["used_storage_gb"] is not None
+        assert data["utilization_pct"] is not None
+        assert 0 <= data["utilization_pct"] <= 100
+
+    def test_storage_null_utilization_without_metrics(self, client):
+        from rds_analyzer.api.routes import _metrics_store
+        _metrics_store.clear()
+        data = client.get("/api/v1/rds/test-api-mysql-001/storage").json()
+        assert data["free_storage_gb"] is None
+        assert data["used_storage_gb"] is None
+        assert data["utilization_pct"] is None
+
+    def test_storage_not_found(self, client):
+        resp = client.get("/api/v1/rds/no-such-instance/storage")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- `GET /rds/{instance_id}/storage` エンドポイントを追加
- ストレージタイプ・割当容量・スナップショット容量・プロビジョンド IOPS を返す
- メトリクスが登録済みの場合は空き容量・使用容量・使用率 (%) も含む
- 5 件のテストを `TestInstanceStorage` クラスとして追加

## Test plan

- [x] `test_storage_returns_200` — 正常系 200 を確認
- [x] `test_storage_contains_required_fields` — 必須フィールドの存在確認
- [x] `test_storage_includes_utilization_when_metrics_exist` — メトリクスあり時に使用率が返る
- [x] `test_storage_null_utilization_without_metrics` — メトリクスなし時に null が返る
- [x] `test_storage_not_found` — 未登録インスタンスは 404

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_