### PR TITLE
feat: GET /rds/{id}/engine — エンジン情報エンドポイント

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,39 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+
+
+# ============================================================
+# エンジン情報エンドポイント
+# ============================================================
+
+@router.get(
+    "/rds/{instance_id}/engine",
+    response_model=dict,
+    tags=["instance"],
+    summary="インスタンスのエンジン情報を取得",
+)
+async def get_instance_engine(instance_id: str) -> dict:
+    """
+    DBエンジン種別・バージョン・マルチAZ設定・リージョンなど
+    エンジン関連のメタ情報を返す。
+    """
+    instance = get_instance_or_404(instance_id)
+
+    engine_family = instance.engine.value.split("-")[0]  # "aurora-mysql" → "aurora"
+
+    return {
+        "instance_id": instance_id,
+        "engine": instance.engine.value,
+        "engine_family": engine_family,
+        "engine_version": instance.engine_version,
+        "instance_class": instance.instance_class,
+        "region": instance.region,
+        "multi_az": instance.multi_az,
+        "read_replica_count": instance.read_replica_count,
+        "backup_retention_days": instance.backup_retention_days,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,37 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+
+
+class TestInstanceEngine:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        from rds_analyzer.api.routes import _instance_store
+        _instance_store.clear()
+        client.post("/api/v1/rds", json=sample_instance_payload)
+
+    def test_engine_returns_200(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/engine")
+        assert resp.status_code == 200
+
+    def test_engine_contains_engine_field(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/engine").json()
+        assert data["engine"] == "mysql"
+        assert data["engine_version"] == "8.0.35"
+
+    def test_engine_family_extracted(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/engine").json()
+        assert data["engine_family"] == "mysql"
+
+    def test_engine_multi_az_field(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/engine").json()
+        assert data["multi_az"] is False
+        assert data["region"] == "ap-northeast-1"
+
+    def test_engine_not_found(self, client):
+        resp = client.get("/api/v1/rds/no-such-instance/engine")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- `GET /rds/{instance_id}/engine` エンドポイントを追加
- エンジン種別・バージョン・エンジンファミリー (aurora-mysql → aurora) を返す
- マルチAZ・リージョン・レプリカ数・バックアップ保持日数を含む
- 5 件のテストを `TestInstanceEngine` クラスとして追加

## Test plan

- [x] `test_engine_returns_200` — 正常系
- [x] `test_engine_contains_engine_field` — エンジン種別・バージョンの確認
- [x] `test_engine_family_extracted` — エンジンファミリー抽出の確認
- [x] `test_engine_multi_az_field` — マルチAZ・リージョンの確認
- [x] `test_engine_not_found` — 未登録は 404

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_