### PR TITLE
feat: GET /rds/{id}/connections — コネクション統計エンドポイント

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,38 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+
+
+# ============================================================
+# コネクション統計エンドポイント
+# ============================================================
+
+@router.get(
+    "/rds/{instance_id}/connections",
+    response_model=dict,
+    tags=["metrics"],
+    summary="インスタンスのコネクション統計を取得",
+)
+async def get_connection_stats(instance_id: str) -> dict:
+    """
+    メトリクスからコネクション統計（平均・最大・推奨上限）を返す。
+
+    メトリクス未投入の場合は 404 を返す。
+    """
+    get_instance_or_404(instance_id)
+    metrics = get_metrics_or_404(instance_id)
+
+    avg_conn = round(metrics.database_connections.avg, 1)
+    max_conn = round(metrics.database_connections.max, 1)
+
+    return {
+        "instance_id": instance_id,
+        "connections_avg": avg_conn,
+        "connections_max": max_conn,
+        "utilization_pct": round(avg_conn / max_conn * 100, 1) if max_conn > 0 else 0.0,
+        "disk_queue_depth_avg": round(metrics.disk_queue_depth.avg, 3),
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,47 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+
+
+class TestConnectionStats:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        from rds_analyzer.api.routes import _instance_store, _metrics_store
+        _instance_store.clear()
+        _metrics_store.clear()
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post(
+            "/api/v1/rds/test-api-mysql-001/metrics",
+            json=sample_metrics_payload,
+        )
+
+    def test_connections_returns_200(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/connections")
+        assert resp.status_code == 200
+
+    def test_connections_contains_required_fields(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/connections").json()
+        assert data["instance_id"] == "test-api-mysql-001"
+        assert "connections_avg" in data
+        assert "connections_max" in data
+        assert "utilization_pct" in data
+
+    def test_connections_values_are_non_negative(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/connections").json()
+        assert data["connections_avg"] >= 0
+        assert data["connections_max"] >= 0
+        assert data["disk_queue_depth_avg"] >= 0
+
+    def test_connections_no_metrics_returns_404(self, client):
+        from rds_analyzer.api.routes import _metrics_store
+        _metrics_store.clear()
+        resp = client.get("/api/v1/rds/test-api-mysql-001/connections")
+        assert resp.status_code == 404
+
+    def test_connections_not_found(self, client):
+        resp = client.get("/api/v1/rds/no-such-instance/connections")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- `GET /rds/{instance_id}/connections` エンドポイントを追加
- メトリクスから平均・最大コネクション数と利用率 (%) を返す
- ディスクキュー深度の平均値も含む
- メトリクス未投入時は 404 を返す

## Test plan

- [x] `test_connections_returns_200` — 正常系
- [x] `test_connections_contains_required_fields` — 必須フィールドの存在確認
- [x] `test_connections_values_are_non_negative` — 値が非負であることを確認
- [x] `test_connections_no_metrics_returns_404` — メトリクスなし時に 404
- [x] `test_connections_not_found` — 未登録インスタンスは 404

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_