### PR TITLE
feat: DELETE /rds/{id} — インスタンス削除エンドポイント (with tests)

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,39 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+
+
+# ============================================================
+# インスタンス削除エンドポイント
+# ============================================================
+
+@router.delete(
+    "/rds/{instance_id}",
+    response_model=dict,
+    tags=["instances"],
+    summary="インスタンスをストアから削除",
+)
+async def delete_instance(instance_id: str) -> dict:
+    """
+    インスタンスとその関連データ（メトリクス・コスト履歴）をストアから削除する。
+
+    存在しないインスタンスを指定した場合は 404 を返す。
+    """
+    get_instance_or_404(instance_id)
+
+    del _instance_store[instance_id]
+    _metrics_store.pop(instance_id, None)
+    _cost_history_store.pop(instance_id, None)
+    _index_analysis_store.pop(instance_id, None)
+
+    logger.info("インスタンス削除: %s", instance_id)
+
+    return {
+        "instance_id": instance_id,
+        "deleted": True,
+        "message": f"インスタンス '{instance_id}' を削除しました",
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,43 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+
+
+class TestInstanceDelete:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        from rds_analyzer.api.routes import _instance_store, _metrics_store
+        _instance_store.clear()
+        _metrics_store.clear()
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post(
+            "/api/v1/rds/test-api-mysql-001/metrics",
+            json=sample_metrics_payload,
+        )
+
+    def test_delete_returns_200(self, client):
+        resp = client.delete("/api/v1/rds/test-api-mysql-001")
+        assert resp.status_code == 200
+
+    def test_delete_response_contains_deleted_true(self, client):
+        data = client.delete("/api/v1/rds/test-api-mysql-001").json()
+        assert data["deleted"] is True
+        assert data["instance_id"] == "test-api-mysql-001"
+
+    def test_deleted_instance_no_longer_accessible(self, client):
+        client.delete("/api/v1/rds/test-api-mysql-001")
+        resp = client.get("/api/v1/rds/test-api-mysql-001/analysis")
+        assert resp.status_code == 404
+
+    def test_delete_clears_metrics(self, client):
+        from rds_analyzer.api.routes import _metrics_store
+        client.delete("/api/v1/rds/test-api-mysql-001")
+        assert "test-api-mysql-001" not in _metrics_store
+
+    def test_delete_not_found(self, client):
+        resp = client.delete("/api/v1/rds/no-such-instance")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- `DELETE /rds/{instance_id}` エンドポイントを追加
- インスタンス・メトリクス・コスト履歴・インデックス分析キャッシュを一括削除
- 不在インスタンス指定時は 404 を返す
- 5 件のテストを `TestInstanceDelete` クラスとして追加

## Test plan

- [x] `test_delete_returns_200` — 正常系
- [x] `test_delete_response_contains_deleted_true` — レスポンス確認
- [x] `test_deleted_instance_no_longer_accessible` — 削除後に 404 になることを確認
- [x] `test_delete_clears_metrics` — メトリクスストアからも削除される
- [x] `test_delete_not_found` — 未登録インスタンスは 404

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_