### PR TITLE
feat: GET /rds/{id}/iops — IOPS 詳細エンドポイント

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,55 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+
+
+# ============================================================
+# IOPS 詳細エンドポイント
+# ============================================================
+
+@router.get(
+    "/rds/{instance_id}/iops",
+    response_model=dict,
+    tags=["metrics"],
+    summary="インスタンスの IOPS 詳細を取得",
+)
+async def get_iops_details(instance_id: str) -> dict:
+    """
+    メトリクスから読み書き IOPS・合計・上限を返す。
+
+    IOPS 上限の算出ルール:
+    - gp2: max(100, allocated_gb × 3)、上限 16000
+    - gp3: provisioned_iops または 3000
+    - io1: provisioned_iops
+    """
+    instance = get_instance_or_404(instance_id)
+    metrics = get_metrics_or_404(instance_id)
+
+    from ..analyzers.performance_analyzer import PerformanceAnalyzer
+    pa = PerformanceAnalyzer()
+    iops_limit = pa.get_iops_limit(instance)
+
+    read_avg = round(metrics.read_iops.avg, 1)
+    write_avg = round(metrics.write_iops.avg, 1)
+    read_max = round(metrics.read_iops.max, 1)
+    write_max = round(metrics.write_iops.max, 1)
+    total_avg = round(read_avg + write_avg, 1)
+    total_max = round(read_max + write_max, 1)
+    utilization_pct = round(total_avg / iops_limit * 100, 1) if iops_limit > 0 else 0.0
+
+    return {
+        "instance_id": instance_id,
+        "storage_type": instance.storage_type.value,
+        "iops_limit": iops_limit,
+        "read_iops_avg": read_avg,
+        "write_iops_avg": write_avg,
+        "total_iops_avg": total_avg,
+        "read_iops_max": read_max,
+        "write_iops_max": write_max,
+        "total_iops_max": total_max,
+        "utilization_pct": utilization_pct,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,45 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+
+
+class TestIopsDetails:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        from rds_analyzer.api.routes import _instance_store, _metrics_store
+        _instance_store.clear()
+        _metrics_store.clear()
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post(
+            "/api/v1/rds/test-api-mysql-001/metrics",
+            json=sample_metrics_payload,
+        )
+
+    def test_iops_returns_200(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/iops")
+        assert resp.status_code == 200
+
+    def test_iops_contains_required_fields(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/iops").json()
+        assert data["instance_id"] == "test-api-mysql-001"
+        assert "iops_limit" in data
+        assert "total_iops_avg" in data
+        assert "utilization_pct" in data
+
+    def test_iops_limit_positive(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/iops").json()
+        assert data["iops_limit"] > 0
+        assert data["read_iops_avg"] >= 0
+        assert data["write_iops_avg"] >= 0
+
+    def test_iops_total_equals_read_plus_write(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/iops").json()
+        assert abs(data["total_iops_avg"] - (data["read_iops_avg"] + data["write_iops_avg"])) < 0.01
+
+    def test_iops_not_found(self, client):
+        resp = client.get("/api/v1/rds/no-such-instance/iops")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- `GET /rds/{instance_id}/iops` エンドポイントを追加
- 読み書き IOPS の平均・最大・合計・ストレージ上限・使用率を返す
- IOPS 上限は `PerformanceAnalyzer.get_iops_limit()` で算出 (gp2/gp3/io1 に対応)
- メトリクス未投入時は 404 を返す

## Test plan

- [x] `test_iops_returns_200` — 正常系
- [x] `test_iops_contains_required_fields` — 必須フィールドの存在確認
- [x] `test_iops_limit_positive` — IOPS 上限が正の値
- [x] `test_iops_total_equals_read_plus_write` — 合計 = 読み + 書きの整合確認
- [x] `test_iops_not_found` — 未登録インスタンスは 404

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_