### PR TITLE
feat: GET /rds/{id}/latency — レイテンシ統計エンドポイント

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,36 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+
+
+# ============================================================
+# レイテンシ統計エンドポイント
+# ============================================================
+
+@router.get(
+    "/rds/{instance_id}/latency",
+    response_model=dict,
+    tags=["metrics"],
+    summary="インスタンスのレイテンシ統計を取得",
+)
+async def get_latency_stats(instance_id: str) -> dict:
+    """
+    メトリクスから読み書きレイテンシ (ms) の平均・最大を返す。
+
+    メトリクス未投入の場合は 404 を返す。
+    """
+    get_instance_or_404(instance_id)
+    metrics = get_metrics_or_404(instance_id)
+
+    return {
+        "instance_id": instance_id,
+        "read_latency_avg_ms": round(metrics.read_latency_ms.avg, 3),
+        "read_latency_max_ms": round(metrics.read_latency_ms.max, 3),
+        "write_latency_avg_ms": round(metrics.write_latency_ms.avg, 3),
+        "write_latency_max_ms": round(metrics.write_latency_ms.max, 3),
+        "disk_queue_depth_avg": round(metrics.disk_queue_depth.avg, 3),
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,45 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+
+
+class TestLatencyStats:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        from rds_analyzer.api.routes import _instance_store, _metrics_store
+        _instance_store.clear()
+        _metrics_store.clear()
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post(
+            "/api/v1/rds/test-api-mysql-001/metrics",
+            json=sample_metrics_payload,
+        )
+
+    def test_latency_returns_200(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/latency")
+        assert resp.status_code == 200
+
+    def test_latency_contains_required_fields(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/latency").json()
+        assert data["instance_id"] == "test-api-mysql-001"
+        assert "read_latency_avg_ms" in data
+        assert "write_latency_avg_ms" in data
+
+    def test_latency_values_match_input(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/latency").json()
+        assert abs(data["read_latency_avg_ms"] - 5.0) < 0.01
+        assert abs(data["write_latency_avg_ms"] - 6.0) < 0.01
+
+    def test_latency_no_metrics_returns_404(self, client):
+        from rds_analyzer.api.routes import _metrics_store
+        _metrics_store.clear()
+        resp = client.get("/api/v1/rds/test-api-mysql-001/latency")
+        assert resp.status_code == 404
+
+    def test_latency_not_found(self, client):
+        resp = client.get("/api/v1/rds/no-such-instance/latency")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- `GET /rds/{instance_id}/latency` エンドポイントを追加
- 読み書きレイテンシ (ms) の平均・最大とディスクキュー深度を返す
- メトリクス未投入時は 404 を返す

## Test plan

- [x] `test_latency_returns_200` — 正常系
- [x] `test_latency_contains_required_fields` — 必須フィールドの存在確認
- [x] `test_latency_values_match_input` — 投入値との一致確認
- [x] `test_latency_no_metrics_returns_404` — メトリクスなし時に 404
- [x] `test_latency_not_found` — 未登録インスタンスは 404

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_