### PR TITLE
feat: GET /rds/{id}/cpu — CPU 使用率統計エンドポイント

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,47 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+
+
+# ============================================================
+# CPU 統計エンドポイント
+# ============================================================
+
+@router.get(
+    "/rds/{instance_id}/cpu",
+    response_model=dict,
+    tags=["metrics"],
+    summary="インスタンスの CPU 使用率統計を取得",
+)
+async def get_cpu_stats(instance_id: str) -> dict:
+    """
+    メトリクスから CPU 使用率 (%) の平均・最大・p95 を返す。
+
+    CPU 効率判定: 理想は 20〜80%。
+    20% 未満はオーバープロビジョニング、80% 超はボトルネックリスク。
+    """
+    get_instance_or_404(instance_id)
+    metrics = get_metrics_or_404(instance_id)
+
+    cpu_avg = round(metrics.cpu_utilization.avg, 1)
+    cpu_max = round(metrics.cpu_utilization.max, 1)
+    cpu_p95 = round(metrics.cpu_utilization.p95, 1)
+
+    if cpu_avg < 20:
+        efficiency_status = "over_provisioned"
+    elif cpu_avg > 80:
+        efficiency_status = "bottleneck_risk"
+    else:
+        efficiency_status = "optimal"
+
+    return {
+        "instance_id": instance_id,
+        "cpu_avg_pct": cpu_avg,
+        "cpu_max_pct": cpu_max,
+        "cpu_p95_pct": cpu_p95,
+        "efficiency_status": efficiency_status,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,43 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+
+
+class TestCpuStats:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        from rds_analyzer.api.routes import _instance_store, _metrics_store
+        _instance_store.clear()
+        _metrics_store.clear()
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post(
+            "/api/v1/rds/test-api-mysql-001/metrics",
+            json=sample_metrics_payload,
+        )
+
+    def test_cpu_returns_200(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/cpu")
+        assert resp.status_code == 200
+
+    def test_cpu_contains_required_fields(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/cpu").json()
+        assert data["instance_id"] == "test-api-mysql-001"
+        assert "cpu_avg_pct" in data
+        assert "cpu_max_pct" in data
+        assert "efficiency_status" in data
+
+    def test_cpu_avg_matches_input(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/cpu").json()
+        assert abs(data["cpu_avg_pct"] - 45.0) < 0.1
+
+    def test_cpu_optimal_efficiency_status(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/cpu").json()
+        assert data["efficiency_status"] == "optimal"
+
+    def test_cpu_not_found(self, client):
+        resp = client.get("/api/v1/rds/no-such-instance/cpu")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- `GET /rds/{instance_id}/cpu` エンドポイントを追加
- CPU 使用率の平均・最大・p95 を返す
- 効率ステータス (`optimal` / `over_provisioned` / `bottleneck_risk`) を算出 (理想: 20〜80%)
- メトリクス未投入時は 404 を返す

## Test plan

- [x] `test_cpu_returns_200` — 正常系
- [x] `test_cpu_contains_required_fields` — 必須フィールドの存在確認
- [x] `test_cpu_avg_matches_input` — 平均値が投入値と一致
- [x] `test_cpu_optimal_efficiency_status` — 45% なので optimal を返す
- [x] `test_cpu_not_found` — 未登録インスタンスは 404

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_