### PR TITLE
feat: GET /rds/{id}/memory — メモリ統計エンドポイント

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,47 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+
+
+# ============================================================
+# メモリ統計エンドポイント
+# ============================================================
+
+@router.get(
+    "/rds/{instance_id}/memory",
+    response_model=dict,
+    tags=["metrics"],
+    summary="インスタンスのメモリ統計を取得",
+)
+async def get_memory_stats(instance_id: str) -> dict:
+    """
+    メトリクスから空きメモリ (GB) の平均・最小と推定使用率を返す。
+
+    インスタンスクラスのスペックから総メモリを算出し、使用率を計算する。
+    """
+    instance = get_instance_or_404(instance_id)
+    metrics = get_metrics_or_404(instance_id)
+
+    from ..analyzers.cost_analyzer import INSTANCE_SPECS
+    gb = 1024 ** 3
+    free_avg_gb = round(metrics.freeable_memory_bytes.avg / gb, 2)
+    free_min_gb = round(metrics.freeable_memory_bytes.min / gb, 2)
+
+    specs = INSTANCE_SPECS.get(instance.instance_class)
+    total_memory_gb = specs["memory_gb"] if specs else None
+    used_avg_gb = round(total_memory_gb - free_avg_gb, 2) if total_memory_gb else None
+    utilization_pct = round(used_avg_gb / total_memory_gb * 100, 1) if total_memory_gb else None
+
+    return {
+        "instance_id": instance_id,
+        "instance_class": instance.instance_class,
+        "total_memory_gb": total_memory_gb,
+        "freeable_memory_avg_gb": free_avg_gb,
+        "freeable_memory_min_gb": free_min_gb,
+        "used_memory_avg_gb": used_avg_gb,
+        "utilization_pct": utilization_pct,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,44 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+
+
+class TestMemoryStats:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        from rds_analyzer.api.routes import _instance_store, _metrics_store
+        _instance_store.clear()
+        _metrics_store.clear()
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post(
+            "/api/v1/rds/test-api-mysql-001/metrics",
+            json=sample_metrics_payload,
+        )
+
+    def test_memory_returns_200(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/memory")
+        assert resp.status_code == 200
+
+    def test_memory_contains_required_fields(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/memory").json()
+        assert data["instance_id"] == "test-api-mysql-001"
+        assert "freeable_memory_avg_gb" in data
+        assert "total_memory_gb" in data
+
+    def test_memory_total_from_instance_class(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/memory").json()
+        assert data["total_memory_gb"] == 8
+        assert data["freeable_memory_avg_gb"] == 3.5
+
+    def test_memory_utilization_calculated(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/memory").json()
+        assert data["utilization_pct"] is not None
+        assert 0 <= data["utilization_pct"] <= 100
+
+    def test_memory_not_found(self, client):
+        resp = client.get("/api/v1/rds/no-such-instance/memory")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- `GET /rds/{instance_id}/memory` エンドポイントを追加
- `INSTANCE_SPECS` からインスタンスクラスの総メモリ (GB) を算出
- 空きメモリ平均・最小・使用メモリ推定・使用率 (%) を返す
- メトリクス未投入時は 404 を返す

## Test plan

- [x] `test_memory_returns_200` — 正常系
- [x] `test_memory_contains_required_fields` — 必須フィールドの存在確認
- [x] `test_memory_total_from_instance_class` — db.m5.large → 8GB、空き 3.5GB の確認
- [x] `test_memory_utilization_calculated` — 使用率が 0〜100% 範囲内
- [x] `test_memory_not_found` — 未登録インスタンスは 404

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_