### PR TITLE
feat: GET /rds/{id}/network — ネットワークスループット統計エンドポイント

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,37 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+
+
+# ============================================================
+# ネットワークスループット統計エンドポイント
+# ============================================================
+
+@router.get(
+    "/rds/{instance_id}/network",
+    response_model=dict,
+    tags=["metrics"],
+    summary="インスタンスのネットワークスループット統計を取得",
+)
+async def get_network_stats(instance_id: str) -> dict:
+    """
+    メトリクスからネットワーク受信・送信スループット (MB/s) の平均・最大を返す。
+
+    メトリクス未投入の場合は 404 を返す。
+    """
+    get_instance_or_404(instance_id)
+    metrics = get_metrics_or_404(instance_id)
+
+    bps_to_mbps = 1 / (1024 * 1024)
+
+    return {
+        "instance_id": instance_id,
+        "network_receive_avg_mbps": round(metrics.network_receive_bps.avg * bps_to_mbps, 3),
+        "network_receive_max_mbps": round(metrics.network_receive_bps.max * bps_to_mbps, 3),
+        "network_transmit_avg_mbps": round(metrics.network_transmit_bps.avg * bps_to_mbps, 3),
+        "network_transmit_max_mbps": round(metrics.network_transmit_bps.max * bps_to_mbps, 3),
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,45 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+
+
+class TestNetworkStats:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        from rds_analyzer.api.routes import _instance_store, _metrics_store
+        _instance_store.clear()
+        _metrics_store.clear()
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post(
+            "/api/v1/rds/test-api-mysql-001/metrics",
+            json=sample_metrics_payload,
+        )
+
+    def test_network_returns_200(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/network")
+        assert resp.status_code == 200
+
+    def test_network_contains_required_fields(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/network").json()
+        assert data["instance_id"] == "test-api-mysql-001"
+        assert "network_receive_avg_mbps" in data
+        assert "network_transmit_avg_mbps" in data
+
+    def test_network_values_non_negative(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/network").json()
+        assert data["network_receive_avg_mbps"] >= 0
+        assert data["network_transmit_avg_mbps"] >= 0
+
+    def test_network_no_metrics_returns_404(self, client):
+        from rds_analyzer.api.routes import _metrics_store
+        _metrics_store.clear()
+        resp = client.get("/api/v1/rds/test-api-mysql-001/network")
+        assert resp.status_code == 404
+
+    def test_network_not_found(self, client):
+        resp = client.get("/api/v1/rds/no-such-instance/network")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- `GET /rds/{instance_id}/network` エンドポイントを追加
- ネットワーク受信・送信スループット (MB/s) の平均・最大を返す
- bps → MB/s 変換を実施
- メトリクス未投入時は 404 を返す

## Test plan

- [x] `test_network_returns_200` — 正常系
- [x] `test_network_contains_required_fields` — 必須フィールドの存在確認
- [x] `test_network_values_non_negative` — 値が非負であることを確認
- [x] `test_network_no_metrics_returns_404` — メトリクスなし時に 404
- [x] `test_network_not_found` — 未登録インスタンスは 404

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_