### PR TITLE
feat: GET /rds/{id}/tags — タグ読み取りエンドポイント

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,30 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+
+
+# ============================================================
+# タグ読み取りエンドポイント
+# ============================================================
+
+@router.get(
+    "/rds/{instance_id}/tags",
+    response_model=dict,
+    tags=["instance"],
+    summary="インスタンスのタグを取得",
+)
+async def get_instance_tags(instance_id: str) -> dict:
+    """
+    インスタンスに設定されたタグ (key-value) の一覧を返す。
+    """
+    instance = get_instance_or_404(instance_id)
+
+    return {
+        "instance_id": instance_id,
+        "tags": instance.tags,
+        "tag_count": len(instance.tags),
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,36 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+
+
+class TestInstanceTagsRead:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        from rds_analyzer.api.routes import _instance_store
+        _instance_store.clear()
+        client.post("/api/v1/rds", json=sample_instance_payload)
+
+    def test_tags_returns_200(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/tags")
+        assert resp.status_code == 200
+
+    def test_tags_contains_correct_tags(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/tags").json()
+        assert data["instance_id"] == "test-api-mysql-001"
+        assert data["tags"] == {"Environment": "test"}
+
+    def test_tags_count_is_correct(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/tags").json()
+        assert data["tag_count"] == 1
+
+    def test_tags_is_dict(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/tags").json()
+        assert isinstance(data["tags"], dict)
+
+    def test_tags_not_found(self, client):
+        resp = client.get("/api/v1/rds/no-such-instance/tags")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- `GET /rds/{instance_id}/tags` エンドポイントを追加
- インスタンスに設定されたタグ (key-value dict) とタグ件数を返す
- 5 件のテストを `TestInstanceTagsRead` クラスとして追加

## Test plan

- [x] `test_tags_returns_200` — 正常系
- [x] `test_tags_contains_correct_tags` — 登録したタグが返ること
- [x] `test_tags_count_is_correct` — タグ件数の確認
- [x] `test_tags_is_dict` — タグが dict 型であること
- [x] `test_tags_not_found` — 未登録インスタンスは 404

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_