### PR TITLE
feat: GET /rds/{id}/specs — インスタンスクラス スペックエンドポイント

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,39 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+
+
+# ============================================================
+# インスタンスクラス スペックエンドポイント
+# ============================================================
+
+@router.get(
+    "/rds/{instance_id}/specs",
+    response_model=dict,
+    tags=["instance"],
+    summary="インスタンスクラスのスペックを取得",
+)
+async def get_instance_specs(instance_id: str) -> dict:
+    """
+    インスタンスクラスの vCPU 数・メモリ容量 (GB) を返す。
+
+    INSTANCE_SPECS に登録されていないクラスの場合は vcpu/memory_gb が null になる。
+    """
+    instance = get_instance_or_404(instance_id)
+    from ..analyzers.cost_analyzer import INSTANCE_SPECS, INSTANCE_HOURLY_RATES
+
+    specs = INSTANCE_SPECS.get(instance.instance_class)
+    hourly_rate = INSTANCE_HOURLY_RATES.get(instance.instance_class)
+
+    return {
+        "instance_id": instance_id,
+        "instance_class": instance.instance_class,
+        "vcpu": specs["vcpu"] if specs else None,
+        "memory_gb": specs["memory_gb"] if specs else None,
+        "hourly_rate_usd": hourly_rate,
+        "monthly_compute_estimate_usd": round(hourly_rate * 24 * 30, 2) if hourly_rate else None,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,39 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+
+
+class TestInstanceSpecs:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        from rds_analyzer.api.routes import _instance_store
+        _instance_store.clear()
+        client.post("/api/v1/rds", json=sample_instance_payload)
+
+    def test_specs_returns_200(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/specs")
+        assert resp.status_code == 200
+
+    def test_specs_vcpu_and_memory(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/specs").json()
+        assert data["instance_class"] == "db.m5.large"
+        assert data["vcpu"] == 2
+        assert data["memory_gb"] == 8
+
+    def test_specs_hourly_rate_present(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/specs").json()
+        assert data["hourly_rate_usd"] is not None
+        assert data["hourly_rate_usd"] > 0
+
+    def test_specs_monthly_estimate_calculated(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/specs").json()
+        assert data["monthly_compute_estimate_usd"] is not None
+        assert data["monthly_compute_estimate_usd"] > 0
+
+    def test_specs_not_found(self, client):
+        resp = client.get("/api/v1/rds/no-such-instance/specs")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- `GET /rds/{instance_id}/specs` エンドポイントを追加
- `INSTANCE_SPECS` から vCPU 数・メモリ容量 (GB) を返す
- `INSTANCE_HOURLY_RATES` から時間単価と推定月額コンピュートコストを算出
- 未登録クラスは vcpu/memory_gb が null になる

## Test plan

- [x] `test_specs_returns_200` — 正常系
- [x] `test_specs_vcpu_and_memory` — db.m5.large → 2 vCPU / 8 GB の確認
- [x] `test_specs_hourly_rate_present` — 時間単価が正の値
- [x] `test_specs_monthly_estimate_calculated` — 月額推定が正の値
- [x] `test_specs_not_found` — 未登録インスタンスは 404

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_