### PR TITLE
feat: GET /rds/{id}/backup — バックアップ設定エンドポイント

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,43 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+
+
+# ============================================================
+# バックアップ設定エンドポイント
+# ============================================================
+
+@router.get(
+    "/rds/{instance_id}/backup",
+    response_model=dict,
+    tags=["instance"],
+    summary="インスタンスのバックアップ設定を取得",
+)
+async def get_backup_config(instance_id: str) -> dict:
+    """
+    バックアップ保持期間・スナップショット容量・バックアップ推奨有無を返す。
+
+    保持期間 0 日はバックアップ無効を示す。
+    7 日未満は RDS のベストプラクティス上「短すぎる」と判定する。
+    """
+    instance = get_instance_or_404(instance_id)
+
+    enabled = instance.backup_retention_days > 0
+    adequate = instance.backup_retention_days >= 7
+
+    return {
+        "instance_id": instance_id,
+        "backup_retention_days": instance.backup_retention_days,
+        "snapshot_storage_gb": instance.snapshot_storage_gb,
+        "backup_enabled": enabled,
+        "retention_adequate": adequate,
+        "recommendation": (
+            "バックアップが無効です。有効化を推奨します。" if not enabled
+            else "保持期間が短すぎます。7日以上を推奨します。" if not adequate
+            else "バックアップ設定は適切です。"
+        ),
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,36 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+
+
+class TestBackupConfig:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        from rds_analyzer.api.routes import _instance_store
+        _instance_store.clear()
+        client.post("/api/v1/rds", json=sample_instance_payload)
+
+    def test_backup_returns_200(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/backup")
+        assert resp.status_code == 200
+
+    def test_backup_retention_days_matches(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/backup").json()
+        assert data["backup_retention_days"] == 7
+        assert data["backup_enabled"] is True
+
+    def test_backup_adequate_for_7_days(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/backup").json()
+        assert data["retention_adequate"] is True
+
+    def test_backup_snapshot_storage_present(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/backup").json()
+        assert data["snapshot_storage_gb"] == 80.0
+
+    def test_backup_not_found(self, client):
+        resp = client.get("/api/v1/rds/no-such-instance/backup")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- `GET /rds/{instance_id}/backup` エンドポイントを追加
- バックアップ保持期間・スナップショット容量・有効/無効・適切性を返す
- 7 日未満は「短すぎる」と判定し推奨メッセージを付与

## Test plan

- [x] `test_backup_returns_200` — 正常系
- [x] `test_backup_retention_days_matches` — 保持期間 7 日・有効確認
- [x] `test_backup_adequate_for_7_days` — 7 日は adequate=True
- [x] `test_backup_snapshot_storage_present` — スナップショット容量の確認
- [x] `test_backup_not_found` — 未登録インスタンスは 404

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_