### PR TITLE
feat: add GET /rds/{id}/health-score lightweight endpoint

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,39 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+@router.get(
+    "/rds/{instance_id}/health-score",
+    response_model=dict,
+    tags=["analysis"],
+    summary="インスタンスのヘルススコアのみを取得",
+)
+async def get_health_score(
+    instance_id: str,
+    perf_analyzer: PerformanceAnalyzer = Depends(get_performance_analyzer),
+) -> dict:
+    instance = get_instance_or_404(instance_id)
+    metrics = get_metrics_or_404(instance_id)
+    perf_result = perf_analyzer.analyze(instance, metrics)
+    score = perf_result.health_score
+    if score >= 80:
+        status = "healthy"
+    elif score >= 50:
+        status = "warning"
+    else:
+        status = "critical"
+    bottleneck_count = sum([
+        perf_result.cpu_bottleneck_detected,
+        perf_result.memory_pressure_detected,
+        perf_result.io_bottleneck_detected,
+        perf_result.connection_bottleneck_detected,
+    ])
+    return {
+        "instance_id": instance_id,
+        "health_score": score,
+        "status": status,
+        "bottleneck_count": bottleneck_count,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,33 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+class TestHealthScore:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post("/api/v1/rds/test-api-mysql-001/metrics", json=sample_metrics_payload)
+
+    def test_health_score_returns_200(self, client):
+        resp = client.get("/api/v1/rds/test-api-mysql-001/health-score")
+        assert resp.status_code == 200
+
+    def test_health_score_in_range(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/health-score").json()
+        assert 0 <= data["health_score"] <= 100
+
+    def test_health_score_has_status(self, client):
+        data = client.get("/api/v1/rds/test-api-mysql-001/health-score").json()
+        assert data["status"] in ("healthy", "warning", "critical")
+
+    def test_health_score_no_metrics_returns_404(self, client, sample_instance_payload):
+        client.post("/api/v1/rds", json={**sample_instance_payload, "instance_id": "no-metrics"})
+        resp = client.get("/api/v1/rds/no-metrics/health-score")
+        assert resp.status_code == 404
+
+    def test_health_score_not_found(self, client):
+        resp = client.get("/api/v1/rds/no-such-instance/health-score")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- Add `GET /rds/{instance_id}/health-score` endpoint for lightweight health checks
- Returns `health_score` (0–100), derived `status` (healthy/warning/critical), and `bottleneck_count`
- Derives status from score: ≥80 → healthy, ≥50 → warning, else → critical
- 5 tests covering 200 response, score range, status values, 404 on missing instance/metrics

## Test plan

- [ ] `pytest tests/test_api.py::TestHealthScore -v` — all 5 pass
- [ ] `GET /rds/{id}/health-score` returns JSON with `health_score`, `status`, `bottleneck_count`
- [ ] Missing instance → 404
- [ ] Missing metrics → 404

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_