### PR TITLE
feat: add GET /rds/{id}/status combined quick-status endpoint

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,36 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+@router.get(
+    "/rds/{instance_id}/status",
+    response_model=dict,
+    tags=["analysis"],
+    summary="インスタンスのクイックステータスを取得",
+)
+async def get_instance_status(
+    instance_id: str,
+    cost_analyzer: CostAnalyzer = Depends(get_cost_analyzer),
+    perf_analyzer: PerformanceAnalyzer = Depends(get_performance_analyzer),
+    rec_engine: RecommendationEngine = Depends(get_recommendation_engine),
+) -> dict:
+    instance = get_instance_or_404(instance_id)
+    metrics = get_metrics_or_404(instance_id)
+    breakdown, _ = cost_analyzer.calculate_monthly_cost(instance)
+    perf_result = perf_analyzer.analyze(instance, metrics)
+    recs = rec_engine.generate_recommendations(instance, perf_result, breakdown)
+    score = perf_result.health_score
+    health_status = "healthy" if score >= 80 else "warning" if score >= 50 else "critical"
+    return {
+        "instance_id": instance_id,
+        "engine": instance.engine.value,
+        "instance_class": instance.instance_class,
+        "region": instance.region,
+        "health_score": score,
+        "health_status": health_status,
+        "monthly_cost_usd": round(breakdown.total_cost_usd, 2),
+        "recommendation_count": len(recs),
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,35 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+class TestInstanceStatus:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        _instance_store.clear(); _metrics_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post("/api/v1/rds/test-api-mysql-001/metrics", json=sample_metrics_payload)
+        yield
+        _instance_store.clear(); _metrics_store.clear()
+
+    def test_status_returns_200(self):
+        assert self._client.get("/api/v1/rds/test-api-mysql-001/status").status_code == 200
+
+    def test_status_has_required_fields(self):
+        data = self._client.get("/api/v1/rds/test-api-mysql-001/status").json()
+        for k in ("instance_id","health_score","health_status","monthly_cost_usd","recommendation_count"):
+            assert k in data
+
+    def test_status_health_score_in_range(self):
+        data = self._client.get("/api/v1/rds/test-api-mysql-001/status").json()
+        assert 0 <= data["health_score"] <= 100
+
+    def test_status_health_status_valid(self):
+        data = self._client.get("/api/v1/rds/test-api-mysql-001/status").json()
+        assert data["health_status"] in ("healthy", "warning", "critical")
+
+    def test_status_not_found(self):
+        assert self._client.get("/api/v1/rds/nonexistent/status").status_code == 404


### PR DESCRIPTION
## Summary

- Add `GET /rds/{instance_id}/status` lightweight overview endpoint
- Returns engine, instance_class, region, health_score, health_status, monthly_cost_usd, recommendation_count
- Designed for dashboard use where full `/analysis` is too heavy
- 5 tests: 200 response, required fields, score range, status validity, 404

## Test plan

- [ ] `pytest tests/test_api.py::TestInstanceStatus -v` — all 5 pass
- [ ] health_status is one of: healthy / warning / critical
- [ ] monthly_cost_usd > 0 for a registered instance

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_