### PR TITLE
feat: add GET /rds/regions endpoint for region discovery

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,13 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+@router.get("/rds/regions", response_model=dict, tags=["instances"], summary="登録インスタンスのリージョン一覧を取得")
+async def list_regions() -> dict:
+    region_counts: dict[str, int] = {}
+    for instance in _instance_store.values():
+        region_counts[instance.region] = region_counts.get(instance.region, 0) + 1
+    return {"regions": sorted(region_counts.keys()), "region_counts": region_counts, "total_regions": len(region_counts)}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,39 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+class TestRegionList:
+    @pytest.fixture(autouse=True)
+    def setup(self, client):
+        _instance_store.clear()
+        self._client = client
+        yield
+        _instance_store.clear()
+
+    def test_empty_regions(self):
+        data = self._client.get("/api/v1/rds/regions").json()
+        assert data["total_regions"] == 0
+
+    def test_regions_with_instances(self, sample_instance_payload):
+        self._client.post("/api/v1/rds", json=sample_instance_payload)
+        data = self._client.get("/api/v1/rds/regions").json()
+        assert "ap-northeast-1" in data["regions"]
+
+    def test_region_counts(self, sample_instance_payload):
+        self._client.post("/api/v1/rds", json=sample_instance_payload)
+        data = self._client.get("/api/v1/rds/regions").json()
+        assert data["region_counts"]["ap-northeast-1"] >= 1
+
+    def test_regions_sorted(self, sample_instance_payload):
+        p2 = {**sample_instance_payload, "instance_id": "inst-us", "region": "us-east-1"}
+        self._client.post("/api/v1/rds", json=sample_instance_payload)
+        self._client.post("/api/v1/rds", json=p2)
+        data = self._client.get("/api/v1/rds/regions").json()
+        assert data["regions"] == sorted(data["regions"])
+
+    def test_regions_structure(self):
+        data = self._client.get("/api/v1/rds/regions").json()
+        assert "regions" in data and "region_counts" in data and "total_regions" in data


### PR DESCRIPTION
## Summary

- Add `GET /rds/regions` endpoint
- Returns sorted list of unique regions, per-region instance counts, and total_regions
- Works with zero instances (empty result)
- 5 tests: empty response, region presence, counts, sort order, structure

## Test plan

- [ ] `pytest tests/test_api.py::TestRegionList -v` — all 5 pass
- [ ] Empty store returns `total_regions: 0`
- [ ] Multi-region setup reflects correct counts

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_