### PR TITLE
feat: add GET /rds/engines endpoint for engine discovery

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,14 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+@router.get("/rds/engines", response_model=dict, tags=["instances"], summary="登録インスタンスのエンジン一覧を取得")
+async def list_engines() -> dict:
+    engine_counts: dict[str, int] = {}
+    for instance in _instance_store.values():
+        engine = instance.engine.value
+        engine_counts[engine] = engine_counts.get(engine, 0) + 1
+    return {"engines": sorted(engine_counts.keys()), "engine_counts": engine_counts, "total_engines": len(engine_counts)}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,37 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+class TestEngineList:
+    @pytest.fixture(autouse=True)
+    def setup(self, client):
+        _instance_store.clear()
+        self._client = client
+        yield
+        _instance_store.clear()
+
+    def test_empty_engines(self):
+        assert self._client.get("/api/v1/rds/engines").json()["total_engines"] == 0
+
+    def test_engines_with_instance(self, sample_instance_payload):
+        self._client.post("/api/v1/rds", json=sample_instance_payload)
+        assert "mysql" in self._client.get("/api/v1/rds/engines").json()["engines"]
+
+    def test_engine_counts(self, sample_instance_payload):
+        self._client.post("/api/v1/rds", json=sample_instance_payload)
+        data = self._client.get("/api/v1/rds/engines").json()
+        assert data["engine_counts"]["mysql"] >= 1
+
+    def test_engines_sorted(self, sample_instance_payload):
+        pg = {**sample_instance_payload, "instance_id": "inst-pg", "engine": "postgresql"}
+        self._client.post("/api/v1/rds", json=sample_instance_payload)
+        self._client.post("/api/v1/rds", json=pg)
+        data = self._client.get("/api/v1/rds/engines").json()
+        assert data["engines"] == sorted(data["engines"])
+
+    def test_engines_structure(self):
+        data = self._client.get("/api/v1/rds/engines").json()
+        assert "engines" in data and "engine_counts" in data and "total_engines" in data


### PR DESCRIPTION
## Summary

- Add `GET /rds/engines` endpoint
- Returns sorted list of unique DB engines, per-engine instance counts, and total_engines
- 5 tests: empty result, engine presence, counts, sort order, structure

## Test plan

- [ ] `pytest tests/test_api.py::TestEngineList -v` — all 5 pass
- [ ] Empty store → total_engines: 0
- [ ] Mixed mysql/postgresql registration → both appear in sorted order

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_