### PR TITLE
feat: add GET /rds/search/by-tag endpoint for tag-based search

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,22 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+@router.get("/rds/search/by-tag", response_model=dict, tags=["instances"], summary="タグでインスタンスを検索")
+async def search_by_tag(
+    key: str = Query(description="タグキー"),
+    value: Optional[str] = Query(default=None, description="タグ値"),
+) -> dict:
+    matched = []
+    for instance in _instance_store.values():
+        tag_val = instance.tags.get(key)
+        if tag_val is None:
+            continue
+        if value is not None and tag_val != value:
+            continue
+        matched.append({"instance_id": instance.instance_id, "engine": instance.engine.value,
+                        "instance_class": instance.instance_class, "region": instance.region, "tag_value": tag_val})
+    return {"search_key": key, "search_value": value, "matched_count": len(matched), "instances": matched}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,35 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+class TestTagSearch:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_search_by_key_found(self):
+        data = self._client.get("/api/v1/rds/search/by-tag?key=Environment").json()
+        assert data["matched_count"] >= 1
+
+    def test_search_by_key_and_value_found(self):
+        data = self._client.get("/api/v1/rds/search/by-tag?key=Environment&value=test").json()
+        assert data["matched_count"] >= 1
+
+    def test_search_by_value_not_matched(self):
+        data = self._client.get("/api/v1/rds/search/by-tag?key=Environment&value=production").json()
+        assert data["matched_count"] == 0
+
+    def test_search_missing_key(self):
+        data = self._client.get("/api/v1/rds/search/by-tag?key=NonExistentTag").json()
+        assert data["matched_count"] == 0
+
+    def test_search_structure(self):
+        data = self._client.get("/api/v1/rds/search/by-tag?key=Environment").json()
+        assert "search_key" in data and "matched_count" in data and "instances" in data


### PR DESCRIPTION
## Summary

- Add `GET /rds/search/by-tag?key=K&value=V` endpoint
- `key` (required): filter instances that have this tag key
- `value` (optional): further filter by exact tag value
- Returns matched instances with instance_id, engine, class, region, tag_value
- 5 tests: key match, key+value match, value mismatch, missing key, response structure

## Test plan

- [ ] `pytest tests/test_api.py::TestTagSearch -v` — all 5 pass
- [ ] `?key=Environment` finds instances tagged with that key
- [ ] `?key=Environment&value=production` returns empty when tag value differs

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_