### PR TITLE
feat: add GET /rds/top-cost endpoint for cost ranking

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,20 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+@router.get("/rds/top-cost", response_model=dict, tags=["costs"], summary="コストが高い上位インスタンスを取得")
+async def top_cost_instances(
+    limit: int = Query(default=5, ge=1, le=50),
+    cost_analyzer: CostAnalyzer = Depends(get_cost_analyzer),
+) -> dict:
+    ranked = []
+    for instance in _instance_store.values():
+        breakdown, _ = cost_analyzer.calculate_monthly_cost(instance)
+        ranked.append({"instance_id": instance.instance_id, "engine": instance.engine.value,
+                       "instance_class": instance.instance_class, "region": instance.region,
+                       "monthly_cost_usd": round(breakdown.total_cost_usd, 2)})
+    ranked.sort(key=lambda x: x["monthly_cost_usd"], reverse=True)
+    return {"limit": limit, "total_instances": len(ranked), "instances": ranked[:limit]}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,35 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+class TestTopCost:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_top_cost_returns_200(self):
+        assert self._client.get("/api/v1/rds/top-cost").status_code == 200
+
+    def test_top_cost_structure(self):
+        data = self._client.get("/api/v1/rds/top-cost").json()
+        assert "limit" in data and "total_instances" in data and "instances" in data
+
+    def test_top_cost_default_limit(self):
+        data = self._client.get("/api/v1/rds/top-cost").json()
+        assert data["limit"] == 5 and len(data["instances"]) <= 5
+
+    def test_top_cost_custom_limit(self):
+        data = self._client.get("/api/v1/rds/top-cost?limit=1").json()
+        assert data["limit"] == 1 and len(data["instances"]) <= 1
+
+    def test_top_cost_empty_store(self):
+        _instance_store.clear()
+        data = self._client.get("/api/v1/rds/top-cost").json()
+        assert data["total_instances"] == 0 and data["instances"] == []


### PR DESCRIPTION
## Summary

- Add `GET /rds/top-cost?limit=N` endpoint
- Returns instances ranked by estimated monthly cost (推定値) descending
- Default limit 5, max 50
- 5 tests: 200 response, structure, default limit, custom limit, empty store

## Test plan

- [ ] `pytest tests/test_api.py::TestTopCost -v` — all 5 pass
- [ ] Returns instances sorted by monthly_cost_usd descending
- [ ] Empty store returns empty list with total_instances: 0

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_