### PR TITLE
feat: add GET /rds/cost-by-engine aggregation endpoint

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,20 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+@router.get("/rds/cost-by-engine", response_model=dict, tags=["costs"], summary="エンジン別の推定月次コスト集計を取得")
+async def cost_by_engine(cost_analyzer: CostAnalyzer = Depends(get_cost_analyzer)) -> dict:
+    engine_costs: dict[str, float] = {}
+    engine_counts: dict[str, int] = {}
+    for instance in _instance_store.values():
+        engine = instance.engine.value
+        breakdown, _ = cost_analyzer.calculate_monthly_cost(instance)
+        engine_costs[engine] = engine_costs.get(engine, 0.0) + breakdown.total_cost_usd
+        engine_counts[engine] = engine_counts.get(engine, 0) + 1
+    total_cost = sum(engine_costs.values())
+    summary = [{"engine": e, "instance_count": engine_counts[e], "total_monthly_cost_usd": round(engine_costs[e], 2)}
+               for e in sorted(engine_costs.keys())]
+    return {"total_monthly_cost_usd": round(total_cost, 2), "by_engine": summary}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,34 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+class TestCostByEngine:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_cost_by_engine_200(self):
+        assert self._client.get("/api/v1/rds/cost-by-engine").status_code == 200
+
+    def test_cost_by_engine_structure(self):
+        data = self._client.get("/api/v1/rds/cost-by-engine").json()
+        assert "total_monthly_cost_usd" in data and "by_engine" in data
+
+    def test_cost_by_engine_has_mysql(self):
+        data = self._client.get("/api/v1/rds/cost-by-engine").json()
+        assert "mysql" in [e["engine"] for e in data["by_engine"]]
+
+    def test_cost_total_positive(self):
+        assert self._client.get("/api/v1/rds/cost-by-engine").json()["total_monthly_cost_usd"] > 0
+
+    def test_cost_by_engine_empty(self):
+        _instance_store.clear()
+        data = self._client.get("/api/v1/rds/cost-by-engine").json()
+        assert data["total_monthly_cost_usd"] == 0 and data["by_engine"] == []


### PR DESCRIPTION
## Summary

- Add `GET /rds/cost-by-engine` endpoint
- Aggregates estimated monthly cost (推定値) grouped by DB engine
- Returns per-engine instance count and cost, plus grand total
- 5 tests: 200 response, structure, mysql presence, positive total, empty store

## Test plan

- [ ] `pytest tests/test_api.py::TestCostByEngine -v` — all 5 pass
- [ ] total_monthly_cost_usd matches sum of by_engine costs
- [ ] Empty store → total: 0.0, by_engine: []

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_