### PR TITLE
feat: add GET /rds/classes endpoint for instance class discovery

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,13 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+@router.get("/rds/classes", response_model=dict, tags=["instances"], summary="使用中のインスタンスクラス一覧を取得")
+async def list_instance_classes() -> dict:
+    class_counts: dict[str, int] = {}
+    for instance in _instance_store.values():
+        class_counts[instance.instance_class] = class_counts.get(instance.instance_class, 0) + 1
+    return {"classes": sorted(class_counts.keys()), "class_counts": class_counts, "total_classes": len(class_counts)}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,35 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+class TestClassList:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_classes_200(self):
+        assert self._client.get("/api/v1/rds/classes").status_code == 200
+
+    def test_classes_structure(self):
+        data = self._client.get("/api/v1/rds/classes").json()
+        assert "classes" in data and "class_counts" in data and "total_classes" in data
+
+    def test_classes_has_m5_large(self):
+        assert "db.m5.large" in self._client.get("/api/v1/rds/classes").json()["classes"]
+
+    def test_classes_sorted(self, sample_instance_payload):
+        p2 = {**sample_instance_payload, "instance_id": "inst-t3", "instance_class": "db.t3.micro"}
+        self._client.post("/api/v1/rds", json=p2)
+        data = self._client.get("/api/v1/rds/classes").json()
+        assert data["classes"] == sorted(data["classes"])
+
+    def test_classes_empty(self):
+        _instance_store.clear()
+        assert self._client.get("/api/v1/rds/classes").json()["total_classes"] == 0


### PR DESCRIPTION
## Summary

- Add `GET /rds/classes` endpoint
- Returns sorted list of unique instance classes (e.g. db.m5.large) in use
- Includes per-class instance counts and total_classes
- 5 tests: 200, structure, m5.large presence, sort order, empty store

## Test plan

- [ ] `pytest tests/test_api.py::TestClassList -v` — all 5 pass
- [ ] Returns sorted class names alphabetically
- [ ] Empty store → total_classes: 0

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_