### PR TITLE
feat: add GET /rds/storage-types endpoint for storage type discovery

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,18 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+@router.get("/rds/storage-types", response_model=dict, tags=["instances"], summary="使用中のストレージタイプ一覧を取得")
+async def list_storage_types() -> dict:
+    type_counts: dict[str, int] = {}
+    type_total_gb: dict[str, int] = {}
+    for instance in _instance_store.values():
+        stype = instance.storage_type.value
+        type_counts[stype] = type_counts.get(stype, 0) + 1
+        type_total_gb[stype] = type_total_gb.get(stype, 0) + instance.allocated_storage_gb
+    summary = [{"storage_type": s, "instance_count": type_counts[s], "total_allocated_gb": type_total_gb[s]}
+               for s in sorted(type_counts.keys())]
+    return {"storage_types": sorted(type_counts.keys()), "total_storage_types": len(type_counts), "by_storage_type": summary}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,34 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+class TestStorageTypeSummary:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_storage_types_200(self):
+        assert self._client.get("/api/v1/rds/storage-types").status_code == 200
+
+    def test_storage_types_structure(self):
+        data = self._client.get("/api/v1/rds/storage-types").json()
+        assert "storage_types" in data and "total_storage_types" in data and "by_storage_type" in data
+
+    def test_storage_types_has_gp2(self):
+        assert "gp2" in self._client.get("/api/v1/rds/storage-types").json()["storage_types"]
+
+    def test_storage_type_gb(self):
+        data = self._client.get("/api/v1/rds/storage-types").json()
+        gp2 = next(s for s in data["by_storage_type"] if s["storage_type"] == "gp2")
+        assert gp2["total_allocated_gb"] >= 100
+
+    def test_storage_types_empty(self):
+        _instance_store.clear()
+        assert self._client.get("/api/v1/rds/storage-types").json()["total_storage_types"] == 0


### PR DESCRIPTION
## Summary

- Add `GET /rds/storage-types` endpoint
- Returns unique storage types (gp2/gp3/io1) across all registered instances
- Includes per-type instance count and total allocated GB
- 5 tests: 200, structure, gp2 presence, allocated GB, empty store

## Test plan

- [ ] `pytest tests/test_api.py::TestStorageTypeSummary -v` — all 5 pass
- [ ] gp2 instance with 100 GB shows total_allocated_gb >= 100
- [ ] Empty store → total_storage_types: 0

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_