### PR TITLE
feat: add GET /rds/multi-az-stats endpoint for HA coverage reporting

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,15 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+@router.get("/rds/multi-az-stats", response_model=dict, tags=["instances"], summary="Multi-AZ配置状況のサマリーを取得")
+async def multi_az_stats() -> dict:
+    total = len(_instance_store)
+    multi_az_count = sum(1 for inst in _instance_store.values() if inst.multi_az)
+    single_az_count = total - multi_az_count
+    multi_az_pct = round(multi_az_count / total * 100, 1) if total > 0 else 0.0
+    return {"total_instances": total, "multi_az_count": multi_az_count,
+            "single_az_count": single_az_count, "multi_az_pct": multi_az_pct}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,36 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+class TestMultiAzStats:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_multi_az_stats_200(self):
+        assert self._client.get("/api/v1/rds/multi-az-stats").status_code == 200
+
+    def test_multi_az_stats_structure(self):
+        data = self._client.get("/api/v1/rds/multi-az-stats").json()
+        assert "total_instances" in data and "multi_az_count" in data and "multi_az_pct" in data
+
+    def test_single_az_instance(self):
+        data = self._client.get("/api/v1/rds/multi-az-stats").json()
+        assert data["single_az_count"] >= 1 and data["multi_az_count"] == 0
+
+    def test_multi_az_enabled(self, sample_instance_payload):
+        maz = {**sample_instance_payload, "instance_id": "inst-maz", "multi_az": True}
+        self._client.post("/api/v1/rds", json=maz)
+        assert self._client.get("/api/v1/rds/multi-az-stats").json()["multi_az_count"] >= 1
+
+    def test_empty_stats(self):
+        _instance_store.clear()
+        data = self._client.get("/api/v1/rds/multi-az-stats").json()
+        assert data["total_instances"] == 0 and data["multi_az_pct"] == 0.0


### PR DESCRIPTION
## Summary

- Add `GET /rds/multi-az-stats` endpoint
- Returns Multi-AZ count, Single-AZ count, total instances, and Multi-AZ adoption percentage
- Useful for HA coverage audits
- 5 tests: 200, structure, single-AZ detection, multi-AZ detection, empty store

## Test plan

- [ ] `pytest tests/test_api.py::TestMultiAzStats -v` — all 5 pass
- [ ] multi_az=false instance → single_az_count >= 1, multi_az_count == 0
- [ ] Empty store → multi_az_pct: 0.0

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_