### PR TITLE
feat: add GET /rds/read-replicas endpoint for replica configuration audit

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,20 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+@router.get("/rds/read-replicas", response_model=dict, tags=["instances"], summary="リードレプリカ設定のサマリーを取得")
+async def read_replica_summary() -> dict:
+    total_instances = len(_instance_store)
+    total_replicas = sum(inst.read_replica_count for inst in _instance_store.values())
+    instances_with_replicas = sum(1 for inst in _instance_store.values() if inst.read_replica_count > 0)
+    replica_distribution: dict[str, int] = {}
+    for inst in _instance_store.values():
+        key = str(inst.read_replica_count)
+        replica_distribution[key] = replica_distribution.get(key, 0) + 1
+    return {"total_instances": total_instances, "total_read_replicas": total_replicas,
+            "instances_with_replicas": instances_with_replicas,
+            "instances_without_replicas": total_instances - instances_with_replicas,
+            "replica_distribution": replica_distribution}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,37 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+class TestReadReplicaSummary:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_read_replicas_200(self):
+        assert self._client.get("/api/v1/rds/read-replicas").status_code == 200
+
+    def test_read_replicas_structure(self):
+        data = self._client.get("/api/v1/rds/read-replicas").json()
+        assert "total_instances" in data and "total_read_replicas" in data and "replica_distribution" in data
+
+    def test_no_replicas_by_default(self):
+        data = self._client.get("/api/v1/rds/read-replicas").json()
+        assert data["instances_without_replicas"] >= 1 and data["total_read_replicas"] == 0
+
+    def test_with_replicas(self, sample_instance_payload):
+        rep = {**sample_instance_payload, "instance_id": "inst-rep", "read_replica_count": 2}
+        self._client.post("/api/v1/rds", json=rep)
+        data = self._client.get("/api/v1/rds/read-replicas").json()
+        assert data["total_read_replicas"] >= 2 and data["instances_with_replicas"] >= 1
+
+    def test_empty_store(self):
+        _instance_store.clear()
+        data = self._client.get("/api/v1/rds/read-replicas").json()
+        assert data["total_instances"] == 0 and data["total_read_replicas"] == 0


### PR DESCRIPTION
## Summary

- Add `GET /rds/read-replicas` endpoint
- Returns total read replicas, instances with/without replicas, and replica count distribution
- Useful for read-scaling and cost audit
- 5 tests: 200, structure, no-replica default, with-replica detection, empty store

## Test plan

- [ ] `pytest tests/test_api.py::TestReadReplicaSummary -v` — all 5 pass
- [ ] Instance with read_replica_count=2 → total_read_replicas >= 2
- [ ] Default instance (0 replicas) → instances_without_replicas >= 1

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_