### PR TITLE
feat: add GET /rds/backup-stats endpoint for fleet backup audit

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,19 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+
+
+
+@router.get("/rds/backup-stats", response_model=dict, tags=["instances"], summary="バックアップ設定のフリート全体サマリーを取得")
+async def backup_stats() -> dict:
+    retention_days = [inst.backup_retention_days for inst in _instance_store.values()]
+    total = len(retention_days)
+    if total == 0:
+        return {"total_instances": 0, "avg_retention_days": 0.0, "min_retention_days": 0,
+                "max_retention_days": 0, "inadequate_backup_count": 0}
+    avg = round(sum(retention_days) / total, 1)
+    inadequate = sum(1 for d in retention_days if d < 7)
+    return {"total_instances": total, "avg_retention_days": avg,
+            "min_retention_days": min(retention_days), "max_retention_days": max(retention_days),
+            "inadequate_backup_count": inadequate}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,37 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+
+
+
+class TestBackupStats:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_backup_stats_200(self):
+        assert self._client.get("/api/v1/rds/backup-stats").status_code == 200
+
+    def test_backup_stats_structure(self):
+        data = self._client.get("/api/v1/rds/backup-stats").json()
+        for k in ("total_instances","avg_retention_days","min_retention_days","max_retention_days","inadequate_backup_count"):
+            assert k in data
+
+    def test_backup_retention_values(self):
+        data = self._client.get("/api/v1/rds/backup-stats").json()
+        assert data["avg_retention_days"] == 7.0 and data["min_retention_days"] == 7
+
+    def test_inadequate_backup_detection(self, sample_instance_payload):
+        low = {**sample_instance_payload, "instance_id": "inst-low-bkp", "backup_retention_days": 3}
+        self._client.post("/api/v1/rds", json=low)
+        assert self._client.get("/api/v1/rds/backup-stats").json()["inadequate_backup_count"] >= 1
+
+    def test_backup_stats_empty(self):
+        _instance_store.clear()
+        data = self._client.get("/api/v1/rds/backup-stats").json()
+        assert data["total_instances"] == 0 and data["avg_retention_days"] == 0.0


### PR DESCRIPTION
## Summary

- Add `GET /rds/backup-stats` endpoint
- Returns avg/min/max backup retention days across all instances
- Flags instances with `backup_retention_days < 7` as inadequate
- 5 tests: 200, structure, retention values, inadequate detection, empty store

## Test plan

- [ ] `pytest tests/test_api.py::TestBackupStats -v` — all 5 pass
- [ ] Instance with retention=3 → inadequate_backup_count >= 1
- [ ] Empty store → all zeroes

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_