### PR TITLE
feat: add GET /rds/total-storage endpoint for fleet storage summary

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -968,3 +968,13 @@ async def cpu_fleet_stats() -> dict:
         "fleet_max_cpu_pct": round(max(cpu_maxes), 2),
         "high_cpu_instances": high_cpu,
     }
+
+
+@router.get("/rds/total-storage", response_model=dict, tags=["costs"], summary="フリート全体のストレージ使用量サマリーを取得")
+async def total_storage_summary() -> dict:
+    total_instances = len(_instance_store)
+    total_allocated_gb = sum(inst.allocated_storage_gb for inst in _instance_store.values())
+    total_snapshot_gb = sum(inst.snapshot_storage_gb for inst in _instance_store.values())
+    avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
+    return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
+            "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -668,3 +668,34 @@ class TestCpuFleetStats:
         data = self._client.get("/api/v1/rds/cpu-fleet-stats").json()
         assert data["instances_with_metrics"] == 0
         assert data["fleet_avg_cpu_pct"] == 0.0
+
+
+class TestTotalStorage:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_total_storage_200(self):
+        assert self._client.get("/api/v1/rds/total-storage").status_code == 200
+
+    def test_total_storage_structure(self):
+        data = self._client.get("/api/v1/rds/total-storage").json()
+        for k in ("total_instances","total_allocated_storage_gb","total_snapshot_storage_gb","avg_allocated_storage_gb"):
+            assert k in data
+
+    def test_total_storage_values(self):
+        data = self._client.get("/api/v1/rds/total-storage").json()
+        assert data["total_allocated_storage_gb"] >= 100
+
+    def test_avg_storage(self):
+        data = self._client.get("/api/v1/rds/total-storage").json()
+        assert data["avg_allocated_storage_gb"] == data["total_allocated_storage_gb"] / data["total_instances"]
+
+    def test_empty_store(self):
+        _instance_store.clear()
+        data = self._client.get("/api/v1/rds/total-storage").json()
+        assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0


### PR DESCRIPTION
## Summary

- Add `GET /rds/total-storage` endpoint
- Returns total_allocated_storage_gb, total_snapshot_storage_gb, avg_allocated_storage_gb, and total_instances
- Gives a fleet-wide storage footprint overview at a glance
- 5 tests: 200, structure, values, avg calculation, empty store

## Test plan

- [ ] `pytest tests/test_api.py::TestTotalStorage -v` — all 5 pass
- [ ] avg == total / count for a single instance
- [ ] Empty store → total_instances: 0, totals: 0

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_