### PR TITLE
feat: add GET /rds/snapshot-stats endpoint for snapshot storage audit

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -968,3 +968,15 @@ async def cpu_fleet_stats() -> dict:
         "fleet_max_cpu_pct": round(max(cpu_maxes), 2),
         "high_cpu_instances": high_cpu,
     }
+
+
+@router.get("/rds/snapshot-stats", response_model=dict, tags=["costs"], summary="フリート全体のスナップショット容量サマリーを取得")
+async def snapshot_stats() -> dict:
+    instances = list(_instance_store.values())
+    total = len(instances)
+    with_snapshots = [inst for inst in instances if inst.snapshot_storage_gb > 0]
+    total_snapshot_gb = sum(inst.snapshot_storage_gb for inst in instances)
+    return {"total_instances": total, "instances_with_snapshots": len(with_snapshots),
+            "instances_without_snapshots": total - len(with_snapshots),
+            "total_snapshot_storage_gb": round(total_snapshot_gb, 2),
+            "avg_snapshot_storage_gb": round(total_snapshot_gb / len(with_snapshots), 2) if with_snapshots else 0.0}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -668,3 +668,35 @@ class TestCpuFleetStats:
         data = self._client.get("/api/v1/rds/cpu-fleet-stats").json()
         assert data["instances_with_metrics"] == 0
         assert data["fleet_avg_cpu_pct"] == 0.0
+
+
+class TestSnapshotStats:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_snapshot_stats_200(self):
+        assert self._client.get("/api/v1/rds/snapshot-stats").status_code == 200
+
+    def test_snapshot_stats_structure(self):
+        data = self._client.get("/api/v1/rds/snapshot-stats").json()
+        for k in ("total_instances","instances_with_snapshots","total_snapshot_storage_gb","avg_snapshot_storage_gb"):
+            assert k in data
+
+    def test_snapshot_gb_positive(self):
+        data = self._client.get("/api/v1/rds/snapshot-stats").json()
+        assert data["total_snapshot_storage_gb"] >= 80.0 and data["instances_with_snapshots"] >= 1
+
+    def test_no_snapshot_instance(self, sample_instance_payload):
+        no_snap = {**sample_instance_payload, "instance_id": "inst-no-snap", "snapshot_storage_gb": 0.0}
+        self._client.post("/api/v1/rds", json=no_snap)
+        assert self._client.get("/api/v1/rds/snapshot-stats").json()["instances_without_snapshots"] >= 1
+
+    def test_empty_store(self):
+        _instance_store.clear()
+        data = self._client.get("/api/v1/rds/snapshot-stats").json()
+        assert data["total_instances"] == 0 and data["avg_snapshot_storage_gb"] == 0.0


### PR DESCRIPTION
## Summary

- Add `GET /rds/snapshot-stats` endpoint
- Returns instances with/without snapshots, total snapshot GB, avg snapshot GB per instance
- Helps identify storage costs from accumulated snapshots
- 5 tests: 200, structure, positive GB, no-snapshot detection, empty store

## Test plan

- [ ] `pytest tests/test_api.py::TestSnapshotStats -v` — all 5 pass
- [ ] Instance with snapshot_storage_gb=80 → total >= 80
- [ ] Instance with snapshot_storage_gb=0 → instances_without_snapshots >= 1

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_