### PR TITLE
feat: add GET /rds/iops-fleet-stats endpoint for fleet IOPS aggregation

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -858,3 +858,30 @@ async def notify_slack(
         "notifications_sent": sent,
         "total": len(sent),
     }
+
+
+@router.get(
+    "/rds/iops-fleet-stats",
+    response_model=dict,
+    tags=["metrics"],
+    summary="フリート全体のIOPS使用状況サマリーを取得",
+)
+async def iops_fleet_stats(
+    perf_analyzer: PerformanceAnalyzer = Depends(get_performance_analyzer),
+) -> dict:
+    """メトリクスが存在するインスタンスのIOPS集計を返す。"""
+    total_avg_iops = 0.0
+    total_max_iops = 0.0
+    covered = 0
+    for iid, metrics in _metrics_store.items():
+        instance = _instance_store.get(iid)
+        if instance is None:
+            continue
+        total_avg_iops += metrics.read_iops.avg + metrics.write_iops.avg
+        total_max_iops += metrics.read_iops.max + metrics.write_iops.max
+        covered += 1
+    return {
+        "instances_with_metrics": covered,
+        "fleet_avg_total_iops": round(total_avg_iops, 2),
+        "fleet_max_total_iops": round(total_max_iops, 2),
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -526,3 +526,42 @@ class TestNotify:
     def test_notify_not_found(self, client):
         resp = client.post("/api/v1/rds/no-such/notify")
         assert resp.status_code == 404
+
+from rds_analyzer.api.routes import _instance_store, _metrics_store
+
+
+class TestIopsFleetStats:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        _instance_store.clear()
+        _metrics_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post("/api/v1/rds/test-api-mysql-001/metrics", json=sample_metrics_payload)
+        yield
+        _instance_store.clear()
+        _metrics_store.clear()
+
+    def test_iops_fleet_200(self):
+        assert self._client.get("/api/v1/rds/iops-fleet-stats").status_code == 200
+
+    def test_iops_fleet_structure(self):
+        data = self._client.get("/api/v1/rds/iops-fleet-stats").json()
+        assert "instances_with_metrics" in data
+        assert "fleet_avg_total_iops" in data
+        assert "fleet_max_total_iops" in data
+
+    def test_iops_fleet_has_data(self):
+        data = self._client.get("/api/v1/rds/iops-fleet-stats").json()
+        assert data["instances_with_metrics"] == 1
+        assert data["fleet_avg_total_iops"] > 0
+
+    def test_iops_max_gte_avg(self):
+        data = self._client.get("/api/v1/rds/iops-fleet-stats").json()
+        assert data["fleet_max_total_iops"] >= data["fleet_avg_total_iops"]
+
+    def test_iops_fleet_no_metrics(self):
+        _metrics_store.clear()
+        data = self._client.get("/api/v1/rds/iops-fleet-stats").json()
+        assert data["instances_with_metrics"] == 0
+        assert data["fleet_avg_total_iops"] == 0.0


### PR DESCRIPTION
## Summary

- Add `GET /rds/iops-fleet-stats` endpoint
- Aggregates avg and max total IOPS across all instances that have metrics
- Skips instances without metrics gracefully
- 5 tests: 200, structure, data presence, max≥avg invariant, no-metrics case

## Test plan

- [ ] `pytest tests/test_api.py::TestIopsFleetStats -v` — all 5 pass
- [ ] fleet_max_total_iops >= fleet_avg_total_iops
- [ ] No metrics → instances_with_metrics: 0, fleet_avg: 0.0

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_