### PR TITLE
feat: add GET /rds/cpu-fleet-stats endpoint for fleet CPU aggregation

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -858,3 +858,30 @@ async def notify_slack(
         "notifications_sent": sent,
         "total": len(sent),
     }
+
+
+@router.get(
+    "/rds/cpu-fleet-stats",
+    response_model=dict,
+    tags=["metrics"],
+    summary="フリート全体のCPU使用率サマリーを取得",
+)
+async def cpu_fleet_stats() -> dict:
+    """メトリクスが存在するインスタンスのCPU使用率集計を返す。"""
+    cpu_avgs = []
+    cpu_maxes = []
+    for iid, metrics in _metrics_store.items():
+        if iid not in _instance_store:
+            continue
+        cpu_avgs.append(metrics.cpu_utilization.avg)
+        cpu_maxes.append(metrics.cpu_utilization.max)
+    count = len(cpu_avgs)
+    if count == 0:
+        return {"instances_with_metrics": 0, "fleet_avg_cpu_pct": 0.0, "fleet_max_cpu_pct": 0.0, "high_cpu_instances": 0}
+    high_cpu = sum(1 for v in cpu_avgs if v >= 80)
+    return {
+        "instances_with_metrics": count,
+        "fleet_avg_cpu_pct": round(sum(cpu_avgs) / count, 2),
+        "fleet_max_cpu_pct": round(max(cpu_maxes), 2),
+        "high_cpu_instances": high_cpu,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -526,3 +526,43 @@ class TestNotify:
     def test_notify_not_found(self, client):
         resp = client.post("/api/v1/rds/no-such/notify")
         assert resp.status_code == 404
+
+from rds_analyzer.api.routes import _instance_store, _metrics_store
+
+
+class TestCpuFleetStats:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        _instance_store.clear()
+        _metrics_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post("/api/v1/rds/test-api-mysql-001/metrics", json=sample_metrics_payload)
+        yield
+        _instance_store.clear()
+        _metrics_store.clear()
+
+    def test_cpu_fleet_200(self):
+        assert self._client.get("/api/v1/rds/cpu-fleet-stats").status_code == 200
+
+    def test_cpu_fleet_structure(self):
+        data = self._client.get("/api/v1/rds/cpu-fleet-stats").json()
+        assert "instances_with_metrics" in data
+        assert "fleet_avg_cpu_pct" in data
+        assert "fleet_max_cpu_pct" in data
+        assert "high_cpu_instances" in data
+
+    def test_cpu_fleet_values(self):
+        data = self._client.get("/api/v1/rds/cpu-fleet-stats").json()
+        assert data["instances_with_metrics"] == 1
+        assert 0 <= data["fleet_avg_cpu_pct"] <= 100
+
+    def test_cpu_max_gte_avg(self):
+        data = self._client.get("/api/v1/rds/cpu-fleet-stats").json()
+        assert data["fleet_max_cpu_pct"] >= data["fleet_avg_cpu_pct"]
+
+    def test_cpu_fleet_no_metrics(self):
+        _metrics_store.clear()
+        data = self._client.get("/api/v1/rds/cpu-fleet-stats").json()
+        assert data["instances_with_metrics"] == 0
+        assert data["fleet_avg_cpu_pct"] == 0.0


### PR DESCRIPTION
## Summary

- Add `GET /rds/cpu-fleet-stats` endpoint
- Returns fleet avg CPU %, fleet max CPU %, and count of high-CPU instances (avg ≥ 80%)
- Skips instances without metrics; returns zeroes if no metrics exist
- 5 tests: 200, structure, valid values, max≥avg, no-metrics case

## Test plan

- [ ] `pytest tests/test_api.py::TestCpuFleetStats -v` — all 5 pass
- [ ] fleet_max_cpu_pct >= fleet_avg_cpu_pct
- [ ] No metrics → fleet_avg_cpu_pct: 0.0, high_cpu_instances: 0

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_