### PR TITLE
feat: add GET /rds/{id}/alerts endpoint to retrieve alert thresholds

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,15 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/{instance_id}/alerts",
+    response_model=AlertThresholds,
+    tags=["alerts"],
+    summary="インスタンスのアラートしきい値を取得",
+)
+async def get_alert_thresholds(instance_id: str) -> AlertThresholds:
+    """登録済みアラートしきい値を返す。未設定の場合はデフォルト値を返す。"""
+    if instance_id not in _instance_store:
+        raise HTTPException(status_code=404, detail=f"Instance {instance_id!r} not found")
+    return _alert_thresholds_store.get(instance_id, AlertThresholds())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,36 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestGetAlertThresholds:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        _alert_thresholds_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+        _alert_thresholds_store.clear()
+
+    def test_get_alerts_200(self):
+        assert self._client.get("/api/v1/rds/test-instance-001/alerts").status_code == 200
+
+    def test_get_alerts_default_cpu_warn(self):
+        data = self._client.get("/api/v1/rds/test-instance-001/alerts").json()
+        assert data["cpu_warn_pct"] == 80.0
+
+    def test_get_alerts_default_cpu_critical(self):
+        data = self._client.get("/api/v1/rds/test-instance-001/alerts").json()
+        assert data["cpu_critical_pct"] == 95.0
+
+    def test_get_alerts_404(self):
+        assert self._client.get("/api/v1/rds/nonexistent/alerts").status_code == 404
+
+    def test_get_alerts_after_set(self):
+        payload = {"cpu_warn_pct": 70.0, "cpu_critical_pct": 90.0,
+                   "free_storage_warn_gb": 15.0, "free_storage_critical_gb": 3.0,
+                   "read_latency_warn_ms": 25.0, "read_latency_critical_ms": 120.0}
+        self._client.post("/api/v1/rds/test-instance-001/alerts", json=payload)
+        data = self._client.get("/api/v1/rds/test-instance-001/alerts").json()
+        assert data["cpu_warn_pct"] == 70.0


### PR DESCRIPTION
## Summary

- Adds `GET /rds/{instance_id}/alerts` endpoint that returns the current alert threshold configuration for an instance
- Returns default `AlertThresholds` values when no custom thresholds have been set via `POST /rds/{id}/alerts`
- Returns 404 when the instance does not exist

## Test plan

- `TestGetAlertThresholds::test_get_alerts_200` — 200 on registered instance
- `TestGetAlertThresholds::test_get_alerts_default_cpu_warn` — default `cpu_warn_pct` = 80.0
- `TestGetAlertThresholds::test_get_alerts_default_cpu_critical` — default `cpu_critical_pct` = 95.0
- `TestGetAlertThresholds::test_get_alerts_404` — 404 on unknown instance
- `TestGetAlertThresholds::test_get_alerts_after_set` — reflects updated thresholds after POST

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_