### PR TITLE
feat: add GET /rds/fleet-health endpoint for fleet-wide health summary

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,40 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/fleet-health",
+    response_model=dict,
+    tags=["instances"],
+    summary="フリート全体の健全性サマリーを取得",
+)
+async def fleet_health_summary(
+    perf_analyzer: PerformanceAnalyzer = Depends(get_performance_analyzer),
+) -> dict:
+    """全インスタンスの健全性スコアを集計して返す。"""
+    scores = []
+    for iid, instance in _instance_store.items():
+        metrics = _metrics_store.get(iid)
+        if metrics is None:
+            continue
+        result = perf_analyzer.analyze(instance, metrics)
+        scores.append(result.health_score)
+    count = len(scores)
+    if count == 0:
+        return {
+            "total_instances": len(_instance_store),
+            "instances_with_metrics": 0,
+            "avg_health_score": 0,
+            "min_health_score": 0,
+            "max_health_score": 0,
+            "critical_instances": 0,
+        }
+    critical = sum(1 for s in scores if s < 50)
+    return {
+        "total_instances": len(_instance_store),
+        "instances_with_metrics": count,
+        "avg_health_score": round(sum(scores) / count),
+        "min_health_score": min(scores),
+        "max_health_score": max(scores),
+        "critical_instances": critical,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,34 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestFleetHealth:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        _instance_store.clear()
+        _metrics_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post("/api/v1/rds/test-instance-001/metrics", json=sample_metrics_payload)
+        yield
+        _instance_store.clear()
+        _metrics_store.clear()
+
+    def test_fleet_health_200(self):
+        assert self._client.get("/api/v1/rds/fleet-health").status_code == 200
+
+    def test_fleet_health_structure(self):
+        data = self._client.get("/api/v1/rds/fleet-health").json()
+        for k in ("total_instances", "instances_with_metrics", "avg_health_score",
+                  "min_health_score", "max_health_score", "critical_instances"):
+            assert k in data
+
+    def test_fleet_health_score_range(self):
+        data = self._client.get("/api/v1/rds/fleet-health").json()
+        assert 0 <= data["avg_health_score"] <= 100
+
+    def test_fleet_health_no_metrics(self):
+        _metrics_store.clear()
+        data = self._client.get("/api/v1/rds/fleet-health").json()
+        assert data["instances_with_metrics"] == 0
+        assert data["avg_health_score"] == 0


### PR DESCRIPTION
## Summary

- Adds `GET /rds/fleet-health` endpoint that aggregates `PerformanceAnalyzer` health scores across all instances with metrics
- Returns `avg_health_score`, `min_health_score`, `max_health_score`, and count of `critical_instances` (score < 50)
- Gracefully handles the case where no instances have metrics (returns zeros)

## Test plan

- `TestFleetHealth::test_fleet_health_200` — 200 response
- `TestFleetHealth::test_fleet_health_structure` — all expected keys present
- `TestFleetHealth::test_fleet_health_score_range` — `avg_health_score` in [0, 100]
- `TestFleetHealth::test_fleet_health_no_metrics` — returns zeros when metrics store is empty

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_