### PR TITLE
feat: add GET /rds/{id}/recommendations/count endpoint

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,32 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/{instance_id}/recommendations/count",
+    response_model=dict,
+    tags=["recommendations"],
+    summary="推奨事項の件数を優先度別に取得",
+)
+async def recommendations_count(
+    instance_id: str,
+    cost_analyzer: CostAnalyzer = Depends(get_cost_analyzer),
+    perf_analyzer: PerformanceAnalyzer = Depends(get_performance_analyzer),
+    rec_engine: RecommendationEngine = Depends(get_recommendation_engine),
+) -> dict:
+    """優先度別（critical/high/medium/low）の推奨事項件数を返す。"""
+    instance = _instance_store.get(instance_id)
+    if instance is None:
+        raise HTTPException(status_code=404, detail=f"Instance {instance_id!r} not found")
+    metrics = _metrics_store.get(instance_id)
+    if metrics is None:
+        return {"instance_id": instance_id, "total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0}
+    breakdown, _ = cost_analyzer.calculate_monthly_cost(instance)
+    perf_result = perf_analyzer.analyze(instance, metrics)
+    recs = rec_engine.generate(instance, breakdown, perf_result)
+    counts: dict[str, int] = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+    for r in recs:
+        p = r.priority.value if hasattr(r.priority, "value") else str(r.priority)
+        if p in counts:
+            counts[p] += 1
+    return {"instance_id": instance_id, "total": len(recs), **counts}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,35 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestRecommendationsCount:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        _instance_store.clear()
+        _metrics_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post("/api/v1/rds/test-instance-001/metrics", json=sample_metrics_payload)
+        yield
+        _instance_store.clear()
+        _metrics_store.clear()
+
+    def test_count_200(self):
+        assert self._client.get("/api/v1/rds/test-instance-001/recommendations/count").status_code == 200
+
+    def test_count_structure(self):
+        data = self._client.get("/api/v1/rds/test-instance-001/recommendations/count").json()
+        for k in ("instance_id", "total", "critical", "high", "medium", "low"):
+            assert k in data
+
+    def test_count_total_equals_sum(self):
+        data = self._client.get("/api/v1/rds/test-instance-001/recommendations/count").json()
+        assert data["total"] == data["critical"] + data["high"] + data["medium"] + data["low"]
+
+    def test_count_404(self):
+        assert self._client.get("/api/v1/rds/nonexistent/recommendations/count").status_code == 404
+
+    def test_count_no_metrics(self):
+        _metrics_store.clear()
+        data = self._client.get("/api/v1/rds/test-instance-001/recommendations/count").json()
+        assert data["total"] == 0


### PR DESCRIPTION
## Summary

- Adds `GET /rds/{instance_id}/recommendations/count` endpoint that returns recommendation counts broken down by priority (critical / high / medium / low)
- Returns zeros for all priorities when no metrics are available (does not 404)
- Returns 404 when the instance does not exist

## Test plan

- `TestRecommendationsCount::test_count_200` — 200 on registered instance with metrics
- `TestRecommendationsCount::test_count_structure` — all keys present
- `TestRecommendationsCount::test_count_total_equals_sum` — `total == critical + high + medium + low`
- `TestRecommendationsCount::test_count_404` — 404 on unknown instance
- `TestRecommendationsCount::test_count_no_metrics` — total = 0 when no metrics

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_