### PR TITLE
feat: add GET /rds/{id}/storage-efficiency endpoint

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,31 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/{instance_id}/storage-efficiency",
+    response_model=dict,
+    tags=["metrics"],
+    summary="ストレージ使用効率を取得",
+)
+async def storage_efficiency(instance_id: str) -> dict:
+    """ストレージの使用率と空き容量を分析して返す。"""
+    instance = _instance_store.get(instance_id)
+    if instance is None:
+        raise HTTPException(status_code=404, detail=f"Instance {instance_id!r} not found")
+    metrics = _metrics_store.get(instance_id)
+    if metrics is None:
+        raise HTTPException(status_code=404, detail=f"Metrics for {instance_id!r} not found")
+    free_bytes = metrics.free_storage_bytes.avg
+    free_gb = free_bytes / (1024 ** 3)
+    allocated_gb = instance.allocated_storage_gb
+    used_gb = max(0.0, allocated_gb - free_gb)
+    usage_pct = round(used_gb / allocated_gb * 100, 1) if allocated_gb > 0 else 0.0
+    return {
+        "instance_id": instance_id,
+        "allocated_storage_gb": allocated_gb,
+        "used_storage_gb": round(used_gb, 2),
+        "free_storage_gb": round(free_gb, 2),
+        "storage_usage_pct": usage_pct,
+        "storage_type": instance.storage_type,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,35 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestStorageEfficiency:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        _instance_store.clear()
+        _metrics_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post("/api/v1/rds/test-instance-001/metrics", json=sample_metrics_payload)
+        yield
+        _instance_store.clear()
+        _metrics_store.clear()
+
+    def test_storage_efficiency_200(self):
+        assert self._client.get("/api/v1/rds/test-instance-001/storage-efficiency").status_code == 200
+
+    def test_storage_efficiency_structure(self):
+        data = self._client.get("/api/v1/rds/test-instance-001/storage-efficiency").json()
+        for k in ("instance_id", "allocated_storage_gb", "used_storage_gb",
+                  "free_storage_gb", "storage_usage_pct", "storage_type"):
+            assert k in data
+
+    def test_storage_usage_pct_range(self):
+        data = self._client.get("/api/v1/rds/test-instance-001/storage-efficiency").json()
+        assert 0.0 <= data["storage_usage_pct"] <= 100.0
+
+    def test_storage_instance_404(self):
+        assert self._client.get("/api/v1/rds/nonexistent/storage-efficiency").status_code == 404
+
+    def test_storage_metrics_404(self):
+        _metrics_store.clear()
+        assert self._client.get("/api/v1/rds/test-instance-001/storage-efficiency").status_code == 404


### PR DESCRIPTION
## Summary

- Adds `GET /rds/{instance_id}/storage-efficiency` endpoint that derives storage utilisation from `free_storage_bytes` metrics and the instance's `allocated_storage_gb`
- Returns `used_storage_gb`, `free_storage_gb`, `storage_usage_pct`, and `storage_type`
- Returns 404 for unknown instance or missing metrics

## Test plan

- `TestStorageEfficiency::test_storage_efficiency_200` — 200 response
- `TestStorageEfficiency::test_storage_efficiency_structure` — all keys present
- `TestStorageEfficiency::test_storage_usage_pct_range` — usage % in [0, 100]
- `TestStorageEfficiency::test_storage_instance_404` — 404 for unknown instance
- `TestStorageEfficiency::test_storage_metrics_404` — 404 when no metrics

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_