### PR TITLE
feat: add GET /rds/fleet/cost-breakdown endpoint for aggregate cost analysis

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,33 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/fleet/cost-breakdown",
+    response_model=dict,
+    tags=["costs"],
+    summary="フリート全体のコスト内訳を取得",
+)
+async def fleet_cost_breakdown(
+    cost_analyzer: CostAnalyzer = Depends(get_cost_analyzer),
+) -> dict:
+    """全インスタンスのコストをカテゴリ別に集計して返す。"""
+    total = 0.0
+    breakdown: dict[str, float] = {
+        "compute": 0.0, "storage": 0.0, "iops": 0.0,
+        "backup": 0.0, "replica": 0.0, "transfer": 0.0,
+    }
+    for instance in _instance_store.values():
+        bd, _ = cost_analyzer.calculate_monthly_cost(instance)
+        total += bd.total_cost_usd
+        breakdown["compute"] += bd.compute_cost_usd
+        breakdown["storage"] += bd.storage_cost_usd
+        breakdown["iops"] += bd.iops_cost_usd
+        breakdown["backup"] += bd.backup_cost_usd
+        breakdown["replica"] += bd.replica_compute_cost_usd
+        breakdown["transfer"] += bd.transfer_cost_usd
+    return {
+        "total_instances": len(_instance_store),
+        "total_monthly_cost_usd": round(total, 2),
+        "breakdown": {k: round(v, 2) for k, v in breakdown.items()},
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,36 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestFleetCostBreakdown:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_fleet_cost_breakdown_200(self):
+        assert self._client.get("/api/v1/rds/fleet/cost-breakdown").status_code == 200
+
+    def test_fleet_cost_breakdown_structure(self):
+        data = self._client.get("/api/v1/rds/fleet/cost-breakdown").json()
+        assert "total_instances" in data
+        assert "total_monthly_cost_usd" in data
+        assert "breakdown" in data
+
+    def test_fleet_cost_breakdown_keys(self):
+        data = self._client.get("/api/v1/rds/fleet/cost-breakdown").json()
+        for k in ("compute", "storage", "iops", "backup", "replica", "transfer"):
+            assert k in data["breakdown"]
+
+    def test_fleet_cost_total_positive(self):
+        data = self._client.get("/api/v1/rds/fleet/cost-breakdown").json()
+        assert data["total_monthly_cost_usd"] > 0
+
+    def test_fleet_cost_empty_store(self):
+        _instance_store.clear()
+        data = self._client.get("/api/v1/rds/fleet/cost-breakdown").json()
+        assert data["total_instances"] == 0
+        assert data["total_monthly_cost_usd"] == 0.0


### PR DESCRIPTION
## Summary

- Adds `GET /rds/fleet/cost-breakdown` endpoint that sums `CostBreakdown` fields across all registered instances
- Breakdown categories: compute, storage, iops, backup, replica, transfer
- Returns `total_monthly_cost_usd` and per-category subtotals

## Test plan

- `TestFleetCostBreakdown::test_fleet_cost_breakdown_200` — 200 response
- `TestFleetCostBreakdown::test_fleet_cost_breakdown_structure` — top-level keys present
- `TestFleetCostBreakdown::test_fleet_cost_breakdown_keys` — all breakdown categories present
- `TestFleetCostBreakdown::test_fleet_cost_total_positive` — total > 0 with one instance
- `TestFleetCostBreakdown::test_fleet_cost_empty_store` — graceful empty response

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_