### PR TITLE
feat: add GET /rds/alerts/high-cpu endpoint to list high-CPU instances

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,24 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/alerts/high-cpu",
+    response_model=dict,
+    tags=["alerts"],
+    summary="CPU使用率が高いインスタンス一覧を取得",
+)
+async def high_cpu_instances(threshold_pct: float = 80.0) -> dict:
+    """指定しきい値を超えるCPU使用率のインスタンスを返す。"""
+    flagged = []
+    for iid, metrics in _metrics_store.items():
+        if iid not in _instance_store:
+            continue
+        if metrics.cpu_utilization.avg >= threshold_pct:
+            flagged.append({
+                "instance_id": iid,
+                "cpu_avg_pct": round(metrics.cpu_utilization.avg, 2),
+                "cpu_max_pct": round(metrics.cpu_utilization.max, 2),
+            })
+    flagged.sort(key=lambda x: x["cpu_avg_pct"], reverse=True)
+    return {"threshold_pct": threshold_pct, "count": len(flagged), "instances": flagged}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,36 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestHighCpuInstances:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        _instance_store.clear()
+        _metrics_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post("/api/v1/rds/test-instance-001/metrics", json=sample_metrics_payload)
+        yield
+        _instance_store.clear()
+        _metrics_store.clear()
+
+    def test_high_cpu_200(self):
+        assert self._client.get("/api/v1/rds/alerts/high-cpu").status_code == 200
+
+    def test_high_cpu_structure(self):
+        data = self._client.get("/api/v1/rds/alerts/high-cpu").json()
+        assert "threshold_pct" in data
+        assert "count" in data
+        assert "instances" in data
+
+    def test_high_cpu_default_threshold(self):
+        data = self._client.get("/api/v1/rds/alerts/high-cpu").json()
+        assert data["threshold_pct"] == 80.0
+
+    def test_high_cpu_custom_threshold_zero(self):
+        data = self._client.get("/api/v1/rds/alerts/high-cpu?threshold_pct=0").json()
+        assert data["count"] >= 1
+
+    def test_high_cpu_count_equals_instances(self):
+        data = self._client.get("/api/v1/rds/alerts/high-cpu?threshold_pct=0").json()
+        assert data["count"] == len(data["instances"])


### PR DESCRIPTION
## Summary

- Adds `GET /rds/alerts/high-cpu?threshold_pct=80.0` endpoint that returns all instances whose average CPU utilisation meets or exceeds the threshold
- Results sorted descending by `cpu_avg_pct`
- Default threshold is 80%

## Test plan

- `TestHighCpuInstances::test_high_cpu_200` — 200 response
- `TestHighCpuInstances::test_high_cpu_structure` — keys present
- `TestHighCpuInstances::test_high_cpu_default_threshold` — default threshold = 80.0
- `TestHighCpuInstances::test_high_cpu_custom_threshold_zero` — threshold=0 catches all instances with metrics
- `TestHighCpuInstances::test_high_cpu_count_equals_instances` — count == len(instances)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_