### PR TITLE
feat: add GET /rds/alerts/low-usage endpoint to list under-utilised instances

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,26 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/alerts/low-usage",
+    response_model=dict,
+    tags=["alerts"],
+    summary="使用率が低いインスタンス一覧を取得",
+)
+async def low_usage_instances(cpu_threshold_pct: float = 10.0) -> dict:
+    """CPU使用率が低くリソース過剰なインスタンスを返す。"""
+    flagged = []
+    for iid, metrics in _metrics_store.items():
+        if iid not in _instance_store:
+            continue
+        if metrics.cpu_utilization.avg <= cpu_threshold_pct:
+            instance = _instance_store[iid]
+            flagged.append({
+                "instance_id": iid,
+                "instance_class": instance.instance_class,
+                "cpu_avg_pct": round(metrics.cpu_utilization.avg, 2),
+                "connections_avg": round(metrics.database_connections.avg, 2),
+            })
+    flagged.sort(key=lambda x: x["cpu_avg_pct"])
+    return {"threshold_pct": cpu_threshold_pct, "count": len(flagged), "instances": flagged}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,36 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestLowUsageInstances:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        _instance_store.clear()
+        _metrics_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post("/api/v1/rds/test-instance-001/metrics", json=sample_metrics_payload)
+        yield
+        _instance_store.clear()
+        _metrics_store.clear()
+
+    def test_low_usage_200(self):
+        assert self._client.get("/api/v1/rds/alerts/low-usage").status_code == 200
+
+    def test_low_usage_structure(self):
+        data = self._client.get("/api/v1/rds/alerts/low-usage").json()
+        assert "threshold_pct" in data
+        assert "count" in data
+        assert "instances" in data
+
+    def test_low_usage_high_threshold_catches_instance(self):
+        data = self._client.get("/api/v1/rds/alerts/low-usage?cpu_threshold_pct=100").json()
+        assert data["count"] >= 1
+
+    def test_low_usage_zero_threshold_empty(self):
+        data = self._client.get("/api/v1/rds/alerts/low-usage?cpu_threshold_pct=0").json()
+        assert data["count"] == 0
+
+    def test_low_usage_count_equals_len_instances(self):
+        data = self._client.get("/api/v1/rds/alerts/low-usage?cpu_threshold_pct=100").json()
+        assert data["count"] == len(data["instances"])


### PR DESCRIPTION
## Summary

- Adds `GET /rds/alerts/low-usage?cpu_threshold_pct=10.0` endpoint that returns instances whose average CPU utilisation is at or below the threshold (over-provisioned candidates)
- Results sorted ascending by `cpu_avg_pct`; includes `instance_class` and `connections_avg` for context
- Default threshold is 10%

## Test plan

- `TestLowUsageInstances::test_low_usage_200` — 200 response
- `TestLowUsageInstances::test_low_usage_structure` — keys present
- `TestLowUsageInstances::test_low_usage_high_threshold_catches_instance` — threshold=100 catches all
- `TestLowUsageInstances::test_low_usage_zero_threshold_empty` — threshold=0 catches nothing
- `TestLowUsageInstances::test_low_usage_count_equals_len_instances` — count == len(instances)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_