### PR TITLE
feat: add PUT /rds/{id}/tags endpoint to fully replace instance tags

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,17 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.put(
+    "/rds/{instance_id}/tags",
+    response_model=dict,
+    tags=["instances"],
+    summary="インスタンスのタグを全置換",
+)
+async def replace_instance_tags(instance_id: str, tags: dict[str, str]) -> dict:
+    """タグを指定した内容で完全に置き換える（既存タグはすべて削除）。"""
+    instance = _instance_store.get(instance_id)
+    if instance is None:
+        raise HTTPException(status_code=404, detail=f"Instance {instance_id!r} not found")
+    _instance_store[instance_id] = instance.model_copy(update={"tags": tags})
+    return {"instance_id": instance_id, "tags": tags, "tag_count": len(tags)}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,37 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestReplaceInstanceTags:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_replace_tags_200(self):
+        resp = self._client.put("/api/v1/rds/test-instance-001/tags", json={"env": "prod"})
+        assert resp.status_code == 200
+
+    def test_replace_tags_content(self):
+        resp = self._client.put("/api/v1/rds/test-instance-001/tags", json={"env": "prod", "team": "db"})
+        data = resp.json()
+        assert data["tags"] == {"env": "prod", "team": "db"}
+        assert data["tag_count"] == 2
+
+    def test_replace_tags_clears_old(self):
+        self._client.put("/api/v1/rds/test-instance-001/tags", json={"env": "prod"})
+        resp = self._client.put("/api/v1/rds/test-instance-001/tags", json={"team": "db"})
+        data = resp.json()
+        assert "env" not in data["tags"]
+        assert data["tag_count"] == 1
+
+    def test_replace_tags_empty(self):
+        resp = self._client.put("/api/v1/rds/test-instance-001/tags", json={})
+        assert resp.json()["tag_count"] == 0
+
+    def test_replace_tags_404(self):
+        resp = self._client.put("/api/v1/rds/nonexistent/tags", json={"k": "v"})
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- Adds `PUT /rds/{instance_id}/tags` endpoint that performs a full replacement of all tags on an instance (unlike PATCH which would merge)
- Uses `model_copy(update={"tags": tags})` to update the immutable Pydantic model in the store
- Returns the new tag map and count; returns 404 for unknown instances

## Test plan

- `TestReplaceInstanceTags::test_replace_tags_200` — 200 response
- `TestReplaceInstanceTags::test_replace_tags_content` — returned tags match input
- `TestReplaceInstanceTags::test_replace_tags_clears_old` — second PUT removes keys from first PUT
- `TestReplaceInstanceTags::test_replace_tags_empty` — empty dict accepted, tag_count = 0
- `TestReplaceInstanceTags::test_replace_tags_404` — 404 for unknown instance

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_