### PR TITLE
feat: add DELETE /rds/{id}/data endpoint to reset metrics and cost history

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,23 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.delete(
+    "/rds/{instance_id}/data",
+    response_model=dict,
+    tags=["instances"],
+    summary="インスタンスの計測データをリセット",
+)
+async def reset_instance_data(instance_id: str) -> dict:
+    """メトリクス・コスト履歴をクリアしてインスタンス設定のみ保持する。"""
+    if instance_id not in _instance_store:
+        raise HTTPException(status_code=404, detail=f"Instance {instance_id!r} not found")
+    had_metrics = instance_id in _metrics_store
+    had_cost_history = instance_id in _cost_history_store
+    _metrics_store.pop(instance_id, None)
+    _cost_history_store.pop(instance_id, None)
+    return {
+        "instance_id": instance_id,
+        "metrics_cleared": had_metrics,
+        "cost_history_cleared": had_cost_history,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -592,7 +592,7 @@ class TestNotify:
         resp = client.post("/api/v1/rds/no-such/notify")
         assert resp.status_code == 404
 
-from rds_analyzer.api.routes import _instance_store, _metrics_store
+from rds_analyzer.api.routes import _instance_store, _metrics_store, _cost_history_store
 
 
 class TestIopsFleetStats:
@@ -699,3 +699,36 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestResetInstanceData:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        _instance_store.clear()
+        _metrics_store.clear()
+        _cost_history_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post("/api/v1/rds/test-instance-001/metrics", json=sample_metrics_payload)
+        yield
+        _instance_store.clear()
+        _metrics_store.clear()
+        _cost_history_store.clear()
+
+    def test_reset_data_200(self):
+        assert self._client.delete("/api/v1/rds/test-instance-001/data").status_code == 200
+
+    def test_reset_data_clears_metrics(self):
+        self._client.delete("/api/v1/rds/test-instance-001/data")
+        assert "test-instance-001" not in _metrics_store
+
+    def test_reset_data_keeps_instance(self):
+        self._client.delete("/api/v1/rds/test-instance-001/data")
+        assert "test-instance-001" in _instance_store
+
+    def test_reset_data_response_fields(self):
+        data = self._client.delete("/api/v1/rds/test-instance-001/data").json()
+        assert "metrics_cleared" in data
+        assert "cost_history_cleared" in data
+
+    def test_reset_data_404(self):
+        assert self._client.delete("/api/v1/rds/nonexistent/data").status_code == 404


### PR DESCRIPTION
## Summary

- Adds `DELETE /rds/{instance_id}/data` endpoint that clears `_metrics_store` and `_cost_history_store` for an instance while keeping the instance registration intact
- Useful for resetting stale measurement data without deregistering the instance
- Returns boolean flags `metrics_cleared` and `cost_history_cleared` indicating what was actually present

## Test plan

- `TestResetInstanceData::test_reset_data_200` — 200 response
- `TestResetInstanceData::test_reset_data_clears_metrics` — metrics removed from store
- `TestResetInstanceData::test_reset_data_keeps_instance` — instance remains in instance store
- `TestResetInstanceData::test_reset_data_response_fields` — response includes cleared flags
- `TestResetInstanceData::test_reset_data_404` — 404 for unknown instance

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_