### PR TITLE
feat: add GET /rds/fleet/connections endpoint for fleet-wide connection stats

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,33 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/fleet/connections",
+    response_model=dict,
+    tags=["metrics"],
+    summary="フリート全体のコネクション統計を取得",
+)
+async def fleet_connection_stats() -> dict:
+    """全インスタンスのDB接続数を集計して返す。"""
+    avgs = []
+    maxes = []
+    for iid, metrics in _metrics_store.items():
+        if iid not in _instance_store:
+            continue
+        avgs.append(metrics.database_connections.avg)
+        maxes.append(metrics.database_connections.max)
+    count = len(avgs)
+    if count == 0:
+        return {
+            "instances_with_metrics": 0,
+            "fleet_total_avg_connections": 0.0,
+            "fleet_total_max_connections": 0.0,
+            "fleet_avg_connections_per_instance": 0.0,
+        }
+    return {
+        "instances_with_metrics": count,
+        "fleet_total_avg_connections": round(sum(avgs), 2),
+        "fleet_total_max_connections": round(sum(maxes), 2),
+        "fleet_avg_connections_per_instance": round(sum(avgs) / count, 2),
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,34 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestFleetConnections:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        _instance_store.clear()
+        _metrics_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post("/api/v1/rds/test-instance-001/metrics", json=sample_metrics_payload)
+        yield
+        _instance_store.clear()
+        _metrics_store.clear()
+
+    def test_fleet_connections_200(self):
+        assert self._client.get("/api/v1/rds/fleet/connections").status_code == 200
+
+    def test_fleet_connections_structure(self):
+        data = self._client.get("/api/v1/rds/fleet/connections").json()
+        for k in ("instances_with_metrics", "fleet_total_avg_connections",
+                  "fleet_total_max_connections", "fleet_avg_connections_per_instance"):
+            assert k in data
+
+    def test_fleet_connections_max_gte_avg(self):
+        data = self._client.get("/api/v1/rds/fleet/connections").json()
+        assert data["fleet_total_max_connections"] >= data["fleet_total_avg_connections"]
+
+    def test_fleet_connections_no_metrics(self):
+        _metrics_store.clear()
+        data = self._client.get("/api/v1/rds/fleet/connections").json()
+        assert data["instances_with_metrics"] == 0
+        assert data["fleet_avg_connections_per_instance"] == 0.0


### PR DESCRIPTION
## Summary

- Adds `GET /rds/fleet/connections` endpoint that aggregates `database_connections` statistics across all instances with metrics
- Returns total average, total max, and per-instance average connection counts
- Gracefully handles empty metrics store (returns zeros)

## Test plan

- `TestFleetConnections::test_fleet_connections_200` — 200 response
- `TestFleetConnections::test_fleet_connections_structure` — all keys present
- `TestFleetConnections::test_fleet_connections_max_gte_avg` — max >= avg
- `TestFleetConnections::test_fleet_connections_no_metrics` — zeros when no metrics

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_