### PR TITLE
feat: add GET /rds/fleet/latency endpoint for fleet-wide latency stats

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,35 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/fleet/latency",
+    response_model=dict,
+    tags=["metrics"],
+    summary="フリート全体のレイテンシ統計を取得",
+)
+async def fleet_latency_stats() -> dict:
+    """全インスタンスの読み書きレイテンシを集計して返す。"""
+    read_lats = []
+    write_lats = []
+    for iid, metrics in _metrics_store.items():
+        if iid not in _instance_store:
+            continue
+        read_lats.append(metrics.read_latency_ms.avg)
+        write_lats.append(metrics.write_latency_ms.avg)
+    count = len(read_lats)
+    if count == 0:
+        return {
+            "instances_with_metrics": 0,
+            "fleet_avg_read_latency_ms": 0.0,
+            "fleet_avg_write_latency_ms": 0.0,
+            "fleet_max_read_latency_ms": 0.0,
+            "fleet_max_write_latency_ms": 0.0,
+        }
+    return {
+        "instances_with_metrics": count,
+        "fleet_avg_read_latency_ms": round(sum(read_lats) / count, 3),
+        "fleet_avg_write_latency_ms": round(sum(write_lats) / count, 3),
+        "fleet_max_read_latency_ms": round(max(read_lats), 3),
+        "fleet_max_write_latency_ms": round(max(write_lats), 3),
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,35 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestFleetLatency:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        _instance_store.clear()
+        _metrics_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post("/api/v1/rds/test-instance-001/metrics", json=sample_metrics_payload)
+        yield
+        _instance_store.clear()
+        _metrics_store.clear()
+
+    def test_fleet_latency_200(self):
+        assert self._client.get("/api/v1/rds/fleet/latency").status_code == 200
+
+    def test_fleet_latency_structure(self):
+        data = self._client.get("/api/v1/rds/fleet/latency").json()
+        for k in ("instances_with_metrics", "fleet_avg_read_latency_ms",
+                  "fleet_avg_write_latency_ms", "fleet_max_read_latency_ms",
+                  "fleet_max_write_latency_ms"):
+            assert k in data
+
+    def test_fleet_latency_max_gte_avg_read(self):
+        data = self._client.get("/api/v1/rds/fleet/latency").json()
+        assert data["fleet_max_read_latency_ms"] >= data["fleet_avg_read_latency_ms"]
+
+    def test_fleet_latency_no_metrics(self):
+        _metrics_store.clear()
+        data = self._client.get("/api/v1/rds/fleet/latency").json()
+        assert data["instances_with_metrics"] == 0
+        assert data["fleet_avg_read_latency_ms"] == 0.0


### PR DESCRIPTION
## Summary

- Adds `GET /rds/fleet/latency` endpoint that aggregates `read_latency_ms` and `write_latency_ms` statistics across all instances with metrics
- Returns average and max read/write latency across the fleet
- Gracefully handles empty metrics store (returns zeros)

## Test plan

- `TestFleetLatency::test_fleet_latency_200` — 200 response
- `TestFleetLatency::test_fleet_latency_structure` — all keys present
- `TestFleetLatency::test_fleet_latency_max_gte_avg_read` — max read latency >= avg read latency
- `TestFleetLatency::test_fleet_latency_no_metrics` — zeros when no metrics

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_