### PR TITLE
feat: add GET /rds/{id}/recommendations/by-type endpoint

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,31 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/{instance_id}/recommendations/by-type",
+    response_model=dict,
+    tags=["recommendations"],
+    summary="推奨事項をタイプ別に取得",
+)
+async def recommendations_by_type(
+    instance_id: str,
+    cost_analyzer: CostAnalyzer = Depends(get_cost_analyzer),
+    perf_analyzer: PerformanceAnalyzer = Depends(get_performance_analyzer),
+    rec_engine: RecommendationEngine = Depends(get_recommendation_engine),
+) -> dict:
+    """推奨事項をタイプ（rightsizing/storage_type_change等）でグループ化して返す。"""
+    instance = _instance_store.get(instance_id)
+    if instance is None:
+        raise HTTPException(status_code=404, detail=f"Instance {instance_id!r} not found")
+    metrics = _metrics_store.get(instance_id)
+    if metrics is None:
+        return {"instance_id": instance_id, "total": 0, "by_type": {}}
+    breakdown, _ = cost_analyzer.calculate_monthly_cost(instance)
+    perf_result = perf_analyzer.analyze(instance, metrics)
+    recs = rec_engine.generate(instance, breakdown, perf_result)
+    by_type: dict[str, int] = {}
+    for r in recs:
+        t = r.type.value if hasattr(r.type, "value") else str(r.type)
+        by_type[t] = by_type.get(t, 0) + 1
+    return {"instance_id": instance_id, "total": len(recs), "by_type": by_type}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,37 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestRecommendationsByType:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        _instance_store.clear()
+        _metrics_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post("/api/v1/rds/test-instance-001/metrics", json=sample_metrics_payload)
+        yield
+        _instance_store.clear()
+        _metrics_store.clear()
+
+    def test_by_type_200(self):
+        assert self._client.get("/api/v1/rds/test-instance-001/recommendations/by-type").status_code == 200
+
+    def test_by_type_structure(self):
+        data = self._client.get("/api/v1/rds/test-instance-001/recommendations/by-type").json()
+        assert "instance_id" in data
+        assert "total" in data
+        assert "by_type" in data
+
+    def test_by_type_totals_match(self):
+        data = self._client.get("/api/v1/rds/test-instance-001/recommendations/by-type").json()
+        assert data["total"] == sum(data["by_type"].values())
+
+    def test_by_type_404(self):
+        assert self._client.get("/api/v1/rds/nonexistent/recommendations/by-type").status_code == 404
+
+    def test_by_type_no_metrics(self):
+        _metrics_store.clear()
+        data = self._client.get("/api/v1/rds/test-instance-001/recommendations/by-type").json()
+        assert data["total"] == 0
+        assert data["by_type"] == {}


### PR DESCRIPTION
## Summary

- Adds `GET /rds/{instance_id}/recommendations/by-type` endpoint that groups recommendations by `RecommendationType` (e.g. `scale_down`, `storage_type_change`, `add_read_replica`)
- Returns a `by_type` dict mapping type strings to counts, plus the overall `total`
- Returns 404 for unknown instances; returns empty `by_type` when no metrics are available

## Test plan

- `TestRecommendationsByType::test_by_type_200` — 200 response
- `TestRecommendationsByType::test_by_type_structure` — keys present
- `TestRecommendationsByType::test_by_type_totals_match` — total == sum of by_type values
- `TestRecommendationsByType::test_by_type_404` — 404 for unknown instance
- `TestRecommendationsByType::test_by_type_no_metrics` — total = 0, by_type = {} when no metrics

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_