### PR TITLE
feat: add GET /rds/{id}/uptime-estimate endpoint

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,31 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/{instance_id}/uptime-estimate",
+    response_model=dict,
+    tags=["instances"],
+    summary="インスタンスの可用性推定を取得",
+)
+async def uptime_estimate(instance_id: str) -> dict:
+    """Multi-AZ構成・バックアップ設定から可用性をスコアリングして返す。"""
+    instance = _instance_store.get(instance_id)
+    if instance is None:
+        raise HTTPException(status_code=404, detail=f"Instance {instance_id!r} not found")
+    score = 70
+    if instance.multi_az:
+        score += 20
+    if instance.backup_retention_days >= 7:
+        score += 5
+    if instance.backup_retention_days >= 14:
+        score += 5
+    score = min(score, 100)
+    tier = "high" if score >= 90 else ("medium" if score >= 75 else "low")
+    return {
+        "instance_id": instance_id,
+        "availability_score": score,
+        "availability_tier": tier,
+        "multi_az": instance.multi_az,
+        "backup_retention_days": instance.backup_retention_days,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,31 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestUptimeEstimate:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_uptime_200(self):
+        assert self._client.get("/api/v1/rds/test-instance-001/uptime-estimate").status_code == 200
+
+    def test_uptime_structure(self):
+        data = self._client.get("/api/v1/rds/test-instance-001/uptime-estimate").json()
+        for k in ("instance_id", "availability_score", "availability_tier", "multi_az", "backup_retention_days"):
+            assert k in data
+
+    def test_uptime_score_range(self):
+        data = self._client.get("/api/v1/rds/test-instance-001/uptime-estimate").json()
+        assert 0 <= data["availability_score"] <= 100
+
+    def test_uptime_tier_valid(self):
+        data = self._client.get("/api/v1/rds/test-instance-001/uptime-estimate").json()
+        assert data["availability_tier"] in ("high", "medium", "low")
+
+    def test_uptime_404(self):
+        assert self._client.get("/api/v1/rds/nonexistent/uptime-estimate").status_code == 404


### PR DESCRIPTION
## Summary

- Adds `GET /rds/{instance_id}/uptime-estimate` endpoint that scores availability based on Multi-AZ and backup retention configuration
- Base score 70; +20 for Multi-AZ; +5 for retention ≥7 days; +5 for retention ≥14 days; capped at 100
- Returns `availability_tier`: high (≥90) / medium (≥75) / low (<75)

## Test plan

- `TestUptimeEstimate::test_uptime_200` — 200 response
- `TestUptimeEstimate::test_uptime_structure` — all keys present
- `TestUptimeEstimate::test_uptime_score_range` — score in [0, 100]
- `TestUptimeEstimate::test_uptime_tier_valid` — tier is high/medium/low
- `TestUptimeEstimate::test_uptime_404` — 404 for unknown instance

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_