### PR TITLE
feat: add GET /rds/fleet/engines endpoint for engine distribution

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,20 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/fleet/engines",
+    response_model=dict,
+    tags=["instances"],
+    summary="エンジン別インスタンス数を取得",
+)
+async def fleet_engine_distribution() -> dict:
+    """登録済みインスタンスをエンジン種別ごとに集計して返す。"""
+    counts: dict[str, int] = {}
+    for instance in _instance_store.values():
+        engine = instance.engine.value if hasattr(instance.engine, "value") else str(instance.engine)
+        counts[engine] = counts.get(engine, 0) + 1
+    return {
+        "total_instances": len(_instance_store),
+        "by_engine": counts,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,30 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestFleetEngineDistribution:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_engines_200(self):
+        assert self._client.get("/api/v1/rds/fleet/engines").status_code == 200
+
+    def test_engines_structure(self):
+        data = self._client.get("/api/v1/rds/fleet/engines").json()
+        assert "total_instances" in data
+        assert "by_engine" in data
+
+    def test_engines_count_matches(self):
+        data = self._client.get("/api/v1/rds/fleet/engines").json()
+        assert data["total_instances"] == sum(data["by_engine"].values())
+
+    def test_engines_empty_store(self):
+        _instance_store.clear()
+        data = self._client.get("/api/v1/rds/fleet/engines").json()
+        assert data["total_instances"] == 0
+        assert data["by_engine"] == {}


### PR DESCRIPTION
## Summary

- Adds `GET /rds/fleet/engines` endpoint that groups registered instances by DB engine (mysql / postgresql / aurora-mysql etc.)
- Returns `total_instances` and `by_engine` count map
- Empty store returns `total_instances: 0` and empty `by_engine`

## Test plan

- `TestFleetEngineDistribution::test_engines_200` — 200 response
- `TestFleetEngineDistribution::test_engines_structure` — keys present
- `TestFleetEngineDistribution::test_engines_count_matches` — total == sum of by_engine values
- `TestFleetEngineDistribution::test_engines_empty_store` — graceful empty response

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_