### PR TITLE
feat: add GET /rds/fleet/classes endpoint for instance class distribution

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,20 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/fleet/classes",
+    response_model=dict,
+    tags=["instances"],
+    summary="インスタンスクラス別の分布を取得",
+)
+async def fleet_class_distribution() -> dict:
+    """登録済みインスタンスをインスタンスクラスごとに集計して返す。"""
+    counts: dict[str, int] = {}
+    for instance in _instance_store.values():
+        cls = instance.instance_class
+        counts[cls] = counts.get(cls, 0) + 1
+    return {
+        "total_instances": len(_instance_store),
+        "by_class": counts,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,28 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestFleetClassDistribution:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_classes_200(self):
+        assert self._client.get("/api/v1/rds/fleet/classes").status_code == 200
+
+    def test_classes_structure(self):
+        data = self._client.get("/api/v1/rds/fleet/classes").json()
+        assert "total_instances" in data
+        assert "by_class" in data
+
+    def test_classes_count_matches(self):
+        data = self._client.get("/api/v1/rds/fleet/classes").json()
+        assert data["total_instances"] == sum(data["by_class"].values())
+
+    def test_classes_nonempty(self):
+        data = self._client.get("/api/v1/rds/fleet/classes").json()
+        assert data["total_instances"] >= 1


### PR DESCRIPTION
## Summary

- Adds `GET /rds/fleet/classes` endpoint that groups registered instances by instance class (db.t3.medium, db.r6g.large, etc.)
- Returns `total_instances` and `by_class` count map

## Test plan

- `TestFleetClassDistribution::test_classes_200` — 200 response
- `TestFleetClassDistribution::test_classes_structure` — keys present
- `TestFleetClassDistribution::test_classes_count_matches` — total == sum of by_class values
- `TestFleetClassDistribution::test_classes_nonempty` — at least one instance counted

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_