### PR TITLE
feat: add GET /rds/fleet/regions endpoint for region distribution

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,20 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/fleet/regions",
+    response_model=dict,
+    tags=["instances"],
+    summary="リージョン別インスタンス数を取得",
+)
+async def fleet_region_distribution() -> dict:
+    """登録済みインスタンスをリージョンごとに集計して返す。"""
+    counts: dict[str, int] = {}
+    for instance in _instance_store.values():
+        region = instance.region
+        counts[region] = counts.get(region, 0) + 1
+    return {
+        "total_instances": len(_instance_store),
+        "by_region": counts,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,28 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestFleetRegionDistribution:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_regions_200(self):
+        assert self._client.get("/api/v1/rds/fleet/regions").status_code == 200
+
+    def test_regions_structure(self):
+        data = self._client.get("/api/v1/rds/fleet/regions").json()
+        assert "total_instances" in data
+        assert "by_region" in data
+
+    def test_regions_count_matches(self):
+        data = self._client.get("/api/v1/rds/fleet/regions").json()
+        assert data["total_instances"] == sum(data["by_region"].values())
+
+    def test_regions_default_region_present(self):
+        data = self._client.get("/api/v1/rds/fleet/regions").json()
+        assert "ap-northeast-1" in data["by_region"]


### PR DESCRIPTION
## Summary

- Adds `GET /rds/fleet/regions` endpoint that groups registered instances by AWS region
- Returns `total_instances` and `by_region` count map
- Default region is `ap-northeast-1`

## Test plan

- `TestFleetRegionDistribution::test_regions_200` — 200 response
- `TestFleetRegionDistribution::test_regions_structure` — keys present
- `TestFleetRegionDistribution::test_regions_count_matches` — total == sum of by_region values
- `TestFleetRegionDistribution::test_regions_default_region_present` — ap-northeast-1 in response

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_