### PR TITLE
feat: add GET /rds/fleet/multi-az-ratio endpoint

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,22 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/fleet/multi-az-ratio",
+    response_model=dict,
+    tags=["instances"],
+    summary="フリートのMulti-AZ比率を取得",
+)
+async def fleet_multi_az_ratio() -> dict:
+    """Multi-AZ構成のインスタンス割合を返す。"""
+    total = len(_instance_store)
+    multi_az_count = sum(1 for i in _instance_store.values() if i.multi_az)
+    single_az_count = total - multi_az_count
+    ratio_pct = round(multi_az_count / total * 100, 1) if total > 0 else 0.0
+    return {
+        "total_instances": total,
+        "multi_az_count": multi_az_count,
+        "single_az_count": single_az_count,
+        "multi_az_ratio_pct": ratio_pct,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,33 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestFleetMultiAzRatio:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_multi_az_ratio_200(self):
+        assert self._client.get("/api/v1/rds/fleet/multi-az-ratio").status_code == 200
+
+    def test_multi_az_ratio_structure(self):
+        data = self._client.get("/api/v1/rds/fleet/multi-az-ratio").json()
+        for k in ("total_instances", "multi_az_count", "single_az_count", "multi_az_ratio_pct"):
+            assert k in data
+
+    def test_multi_az_counts_sum(self):
+        data = self._client.get("/api/v1/rds/fleet/multi-az-ratio").json()
+        assert data["multi_az_count"] + data["single_az_count"] == data["total_instances"]
+
+    def test_multi_az_ratio_range(self):
+        data = self._client.get("/api/v1/rds/fleet/multi-az-ratio").json()
+        assert 0.0 <= data["multi_az_ratio_pct"] <= 100.0
+
+    def test_multi_az_empty_store(self):
+        _instance_store.clear()
+        data = self._client.get("/api/v1/rds/fleet/multi-az-ratio").json()
+        assert data["multi_az_ratio_pct"] == 0.0


### PR DESCRIPTION
## Summary

- Adds `GET /rds/fleet/multi-az-ratio` endpoint that reports what fraction of fleet instances run in Multi-AZ mode
- Returns `multi_az_count`, `single_az_count`, and `multi_az_ratio_pct`

## Test plan

- `TestFleetMultiAzRatio::test_multi_az_ratio_200` — 200 response
- `TestFleetMultiAzRatio::test_multi_az_ratio_structure` — all keys present
- `TestFleetMultiAzRatio::test_multi_az_counts_sum` — multi + single == total
- `TestFleetMultiAzRatio::test_multi_az_ratio_range` — ratio in [0, 100]
- `TestFleetMultiAzRatio::test_multi_az_empty_store` — ratio = 0.0 on empty store

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_