### PR TITLE
feat: add GET /rds/fleet/storage-types endpoint for storage type distribution

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,23 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/fleet/storage-types",
+    response_model=dict,
+    tags=["instances"],
+    summary="ストレージタイプ別インスタンス数を取得",
+)
+async def fleet_storage_type_distribution() -> dict:
+    """登録済みインスタンスをストレージタイプごとに集計して返す。"""
+    counts: dict[str, int] = {}
+    total_gb: dict[str, float] = {}
+    for instance in _instance_store.values():
+        st = instance.storage_type.value if hasattr(instance.storage_type, "value") else str(instance.storage_type)
+        counts[st] = counts.get(st, 0) + 1
+        total_gb[st] = total_gb.get(st, 0.0) + instance.allocated_storage_gb
+    return {
+        "total_instances": len(_instance_store),
+        "by_storage_type": counts,
+        "total_gb_by_type": {k: round(v, 1) for k, v in total_gb.items()},
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,30 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestFleetStorageTypes:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_storage_types_200(self):
+        assert self._client.get("/api/v1/rds/fleet/storage-types").status_code == 200
+
+    def test_storage_types_structure(self):
+        data = self._client.get("/api/v1/rds/fleet/storage-types").json()
+        assert "total_instances" in data
+        assert "by_storage_type" in data
+        assert "total_gb_by_type" in data
+
+    def test_storage_types_count_matches(self):
+        data = self._client.get("/api/v1/rds/fleet/storage-types").json()
+        assert data["total_instances"] == sum(data["by_storage_type"].values())
+
+    def test_storage_types_gb_positive(self):
+        data = self._client.get("/api/v1/rds/fleet/storage-types").json()
+        for v in data["total_gb_by_type"].values():
+            assert v > 0


### PR DESCRIPTION
## Summary

- Adds `GET /rds/fleet/storage-types` endpoint that groups instances by storage type (gp2 / gp3 / io1) and totals allocated GB per type
- Returns `by_storage_type` (count map) and `total_gb_by_type` (GB sum map)

## Test plan

- `TestFleetStorageTypes::test_storage_types_200` — 200 response
- `TestFleetStorageTypes::test_storage_types_structure` — all keys present
- `TestFleetStorageTypes::test_storage_types_count_matches` — total == sum of by_storage_type
- `TestFleetStorageTypes::test_storage_types_gb_positive` — all GB values > 0

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_