### PR TITLE
feat: add GET /rds/fleet/backup-stats endpoint for backup retention stats

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,29 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/fleet/backup-stats",
+    response_model=dict,
+    tags=["instances"],
+    summary="フリートのバックアップ保持設定の統計を取得",
+)
+async def fleet_backup_stats() -> dict:
+    """全インスタンスのバックアップ保持日数を集計して返す。"""
+    if not _instance_store:
+        return {
+            "total_instances": 0,
+            "avg_retention_days": 0.0,
+            "min_retention_days": 0,
+            "max_retention_days": 0,
+            "instances_below_7_days": 0,
+        }
+    retentions = [i.backup_retention_days for i in _instance_store.values()]
+    below_7 = sum(1 for r in retentions if r < 7)
+    return {
+        "total_instances": len(_instance_store),
+        "avg_retention_days": round(sum(retentions) / len(retentions), 1),
+        "min_retention_days": min(retentions),
+        "max_retention_days": max(retentions),
+        "instances_below_7_days": below_7,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,34 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestFleetBackupStats:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_backup_stats_200(self):
+        assert self._client.get("/api/v1/rds/fleet/backup-stats").status_code == 200
+
+    def test_backup_stats_structure(self):
+        data = self._client.get("/api/v1/rds/fleet/backup-stats").json()
+        for k in ("total_instances", "avg_retention_days", "min_retention_days",
+                  "max_retention_days", "instances_below_7_days"):
+            assert k in data
+
+    def test_backup_stats_min_lte_max(self):
+        data = self._client.get("/api/v1/rds/fleet/backup-stats").json()
+        assert data["min_retention_days"] <= data["max_retention_days"]
+
+    def test_backup_stats_avg_in_range(self):
+        data = self._client.get("/api/v1/rds/fleet/backup-stats").json()
+        assert data["min_retention_days"] <= data["avg_retention_days"] <= data["max_retention_days"]
+
+    def test_backup_stats_empty_store(self):
+        _instance_store.clear()
+        data = self._client.get("/api/v1/rds/fleet/backup-stats").json()
+        assert data["total_instances"] == 0


### PR DESCRIPTION
## Summary

- Adds `GET /rds/fleet/backup-stats` endpoint that aggregates backup retention days across all instances
- Returns avg / min / max retention and count of instances with retention < 7 days (compliance risk)

## Test plan

- `TestFleetBackupStats::test_backup_stats_200` — 200 response
- `TestFleetBackupStats::test_backup_stats_structure` — all keys present
- `TestFleetBackupStats::test_backup_stats_min_lte_max` — min ≤ max
- `TestFleetBackupStats::test_backup_stats_avg_in_range` — avg between min and max
- `TestFleetBackupStats::test_backup_stats_empty_store` — graceful zero response

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_