### PR TITLE
feat: add GET /rds/fleet/read-replicas endpoint for fleet read-replica summary

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,27 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/fleet/read-replicas",
+    response_model=dict,
+    tags=["instances"],
+    summary="フリート全体のリードレプリカ統計を取得",
+)
+async def fleet_read_replica_summary() -> dict:
+    """全インスタンスのリードレプリカ数を集計して返す。"""
+    total = len(_instance_store)
+    instances_with_replicas = 0
+    total_replicas = 0
+    for instance in _instance_store.values():
+        rc = instance.read_replica_count
+        total_replicas += rc
+        if rc > 0:
+            instances_with_replicas += 1
+    avg_replicas = round(total_replicas / total, 2) if total > 0 else 0.0
+    return {
+        "total_instances": total,
+        "instances_with_replicas": instances_with_replicas,
+        "total_read_replicas": total_replicas,
+        "avg_replicas_per_instance": avg_replicas,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,32 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestFleetReadReplicas:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload):
+        _instance_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        yield
+        _instance_store.clear()
+
+    def test_read_replicas_200(self):
+        assert self._client.get("/api/v1/rds/fleet/read-replicas").status_code == 200
+
+    def test_read_replicas_structure(self):
+        data = self._client.get("/api/v1/rds/fleet/read-replicas").json()
+        for k in ("total_instances", "instances_with_replicas",
+                  "total_read_replicas", "avg_replicas_per_instance"):
+            assert k in data
+
+    def test_read_replicas_counts_valid(self):
+        data = self._client.get("/api/v1/rds/fleet/read-replicas").json()
+        assert data["instances_with_replicas"] <= data["total_instances"]
+        assert data["total_read_replicas"] >= 0
+
+    def test_read_replicas_empty_store(self):
+        _instance_store.clear()
+        data = self._client.get("/api/v1/rds/fleet/read-replicas").json()
+        assert data["total_instances"] == 0
+        assert data["avg_replicas_per_instance"] == 0.0


### PR DESCRIPTION
## Summary

- Adds `GET /rds/fleet/read-replicas` endpoint that aggregates `read_replica_count` across all instances
- Returns total replica count, count of instances that have replicas, and average replicas per instance

## Test plan

- `TestFleetReadReplicas::test_read_replicas_200` — 200 response
- `TestFleetReadReplicas::test_read_replicas_structure` — all keys present
- `TestFleetReadReplicas::test_read_replicas_counts_valid` — instances_with_replicas ≤ total
- `TestFleetReadReplicas::test_read_replicas_empty_store` — graceful zero response

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_