### PR TITLE
feat: add GET /rds/{id}/iops-utilization endpoint

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,33 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/{instance_id}/iops-utilization",
+    response_model=dict,
+    tags=["metrics"],
+    summary="インスタンスのIOPS利用率を取得",
+)
+async def iops_utilization(
+    instance_id: str,
+    perf_analyzer: PerformanceAnalyzer = Depends(get_performance_analyzer),
+) -> dict:
+    """プロビジョニングIOPSに対する実際の使用率を返す。"""
+    instance = _instance_store.get(instance_id)
+    if instance is None:
+        raise HTTPException(status_code=404, detail=f"Instance {instance_id!r} not found")
+    metrics = _metrics_store.get(instance_id)
+    if metrics is None:
+        raise HTTPException(status_code=404, detail=f"Metrics for {instance_id!r} not found")
+    iops_limit = perf_analyzer.get_iops_limit(instance)
+    avg_total_iops = metrics.read_iops.avg + metrics.write_iops.avg
+    max_total_iops = metrics.read_iops.max + metrics.write_iops.max
+    utilization_pct = round(avg_total_iops / iops_limit * 100, 1) if iops_limit > 0 else 0.0
+    return {
+        "instance_id": instance_id,
+        "iops_limit": iops_limit,
+        "avg_total_iops": round(avg_total_iops, 2),
+        "max_total_iops": round(max_total_iops, 2),
+        "avg_iops_utilization_pct": utilization_pct,
+        "storage_type": instance.storage_type,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,35 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestIopsUtilization:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        _instance_store.clear()
+        _metrics_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post("/api/v1/rds/test-instance-001/metrics", json=sample_metrics_payload)
+        yield
+        _instance_store.clear()
+        _metrics_store.clear()
+
+    def test_iops_util_200(self):
+        assert self._client.get("/api/v1/rds/test-instance-001/iops-utilization").status_code == 200
+
+    def test_iops_util_structure(self):
+        data = self._client.get("/api/v1/rds/test-instance-001/iops-utilization").json()
+        for k in ("instance_id", "iops_limit", "avg_total_iops",
+                  "max_total_iops", "avg_iops_utilization_pct", "storage_type"):
+            assert k in data
+
+    def test_iops_util_limit_positive(self):
+        data = self._client.get("/api/v1/rds/test-instance-001/iops-utilization").json()
+        assert data["iops_limit"] > 0
+
+    def test_iops_util_instance_404(self):
+        assert self._client.get("/api/v1/rds/nonexistent/iops-utilization").status_code == 404
+
+    def test_iops_util_metrics_404(self):
+        _metrics_store.clear()
+        assert self._client.get("/api/v1/rds/test-instance-001/iops-utilization").status_code == 404


### PR DESCRIPTION
## Summary

- Adds `GET /rds/{instance_id}/iops-utilization` endpoint that computes actual IOPS usage against the provisioned limit from `PerformanceAnalyzer.get_iops_limit()`
- gp2 limit: max(100, allocated_gb × 3), cap 16000; gp3: 3000 default or provisioned_iops
- Returns `avg_iops_utilization_pct` and raw avg/max IOPS

## Test plan

- `TestIopsUtilization::test_iops_util_200` — 200 response
- `TestIopsUtilization::test_iops_util_structure` — all keys present
- `TestIopsUtilization::test_iops_util_limit_positive` — iops_limit > 0
- `TestIopsUtilization::test_iops_util_instance_404` — 404 for unknown instance
- `TestIopsUtilization::test_iops_util_metrics_404` — 404 when no metrics

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_