### PR TITLE
feat: add GET /rds/{id}/memory-pressure endpoint

### DIFF
--- a/rds_analyzer/api/routes.py
+++ b/rds_analyzer/api/routes.py
@@ -978,3 +978,35 @@ async def total_storage_summary() -> dict:
     avg_allocated_gb = round(total_allocated_gb / total_instances, 1) if total_instances > 0 else 0.0
     return {"total_instances": total_instances, "total_allocated_storage_gb": total_allocated_gb,
             "total_snapshot_storage_gb": round(total_snapshot_gb, 2), "avg_allocated_storage_gb": avg_allocated_gb}
+
+@router.get(
+    "/rds/{instance_id}/memory-pressure",
+    response_model=dict,
+    tags=["metrics"],
+    summary="インスタンスのメモリプレッシャーを取得",
+)
+async def memory_pressure(
+    instance_id: str,
+    cost_analyzer: CostAnalyzer = Depends(get_cost_analyzer),
+) -> dict:
+    """フリーメモリから総メモリに対する使用率とプレッシャーレベルを返す。"""
+    instance = _instance_store.get(instance_id)
+    if instance is None:
+        raise HTTPException(status_code=404, detail=f"Instance {instance_id!r} not found")
+    metrics = _metrics_store.get(instance_id)
+    if metrics is None:
+        raise HTTPException(status_code=404, detail=f"Metrics for {instance_id!r} not found")
+    specs = cost_analyzer.get_instance_specs(instance.instance_class)
+    total_memory_gb = specs.get("memory_gb", 8)
+    free_avg_gb = metrics.freeable_memory_bytes.avg / (1024 ** 3)
+    used_gb = max(0.0, total_memory_gb - free_avg_gb)
+    pressure_pct = round(used_gb / total_memory_gb * 100, 1) if total_memory_gb > 0 else 0.0
+    level = "critical" if pressure_pct >= 90 else ("high" if pressure_pct >= 75 else "normal")
+    return {
+        "instance_id": instance_id,
+        "total_memory_gb": total_memory_gb,
+        "free_memory_avg_gb": round(free_avg_gb, 2),
+        "used_memory_gb": round(used_gb, 2),
+        "memory_pressure_pct": pressure_pct,
+        "pressure_level": level,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -699,3 +699,35 @@ class TestTotalStorage:
         _instance_store.clear()
         data = self._client.get("/api/v1/rds/total-storage").json()
         assert data["total_instances"] == 0 and data["total_allocated_storage_gb"] == 0
+
+class TestMemoryPressure:
+    @pytest.fixture(autouse=True)
+    def setup(self, client, sample_instance_payload, sample_metrics_payload):
+        _instance_store.clear()
+        _metrics_store.clear()
+        self._client = client
+        client.post("/api/v1/rds", json=sample_instance_payload)
+        client.post("/api/v1/rds/test-instance-001/metrics", json=sample_metrics_payload)
+        yield
+        _instance_store.clear()
+        _metrics_store.clear()
+
+    def test_memory_pressure_200(self):
+        assert self._client.get("/api/v1/rds/test-instance-001/memory-pressure").status_code == 200
+
+    def test_memory_pressure_structure(self):
+        data = self._client.get("/api/v1/rds/test-instance-001/memory-pressure").json()
+        for k in ("instance_id", "total_memory_gb", "free_memory_avg_gb",
+                  "used_memory_gb", "memory_pressure_pct", "pressure_level"):
+            assert k in data
+
+    def test_memory_pressure_level_valid(self):
+        data = self._client.get("/api/v1/rds/test-instance-001/memory-pressure").json()
+        assert data["pressure_level"] in ("normal", "high", "critical")
+
+    def test_memory_pressure_instance_404(self):
+        assert self._client.get("/api/v1/rds/nonexistent/memory-pressure").status_code == 404
+
+    def test_memory_pressure_metrics_404(self):
+        _metrics_store.clear()
+        assert self._client.get("/api/v1/rds/test-instance-001/memory-pressure").status_code == 404


### PR DESCRIPTION
## Summary

- Adds `GET /rds/{instance_id}/memory-pressure` endpoint that derives memory usage from `freeable_memory_bytes` metrics and `INSTANCE_SPECS` total memory
- Returns `memory_pressure_pct` and `pressure_level`: normal (<75%) / high (75–89%) / critical (≥90%)

## Test plan

- `TestMemoryPressure::test_memory_pressure_200` — 200 response
- `TestMemoryPressure::test_memory_pressure_structure` — all keys present
- `TestMemoryPressure::test_memory_pressure_level_valid` — level is normal/high/critical
- `TestMemoryPressure::test_memory_pressure_instance_404` — 404 for unknown instance
- `TestMemoryPressure::test_memory_pressure_metrics_404` — 404 when no metrics

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y29RYnhq2hfhYUnwA8yJG)_